### PR TITLE
Bug fix for registered benchmarks reuse + allow all optional garak cli params

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ This repository implements [Garak](https://github.com/NVIDIA/garak) as a Llama S
 
 ## Features
 - **Security Vulnerability Detection**: Automated testing for prompt injection, jailbreaks, toxicity, and bias
-- **Compliance Framework Support**: Pre-built profiles for established standards (OWASP LLM Top 10, AVID taxonomy)
-- **Auto-Registered Benchmarks**: All frameworks automatically available as discoverable benchmarks
+- **Compliance Framework Support**: Pre-built benchmarks for established standards ([OWASP LLM Top 10](https://genai.owasp.org/llm-top-10/), [AVID taxonomy](https://docs.avidml.org/taxonomy/effect-sep-view))
 - **Shield Integration**: Test LLMs with and without Llama Stack shields for comparative security analysis
 - **Concurrency Control**: Configurable limits for concurrent scans and shield operations
 - **Custom Probe Support**: Run specific garak security probes
@@ -76,17 +75,18 @@ Pre-registered compliance framework benchmarks available immediately:
 ### Compliance Standards
 | Framework | Benchmark ID | Description | Duration |
 |-----------|--------------|--------------| --------|
-| **OWASP LLM Top 10** | `owasp_llm_top10` | OWASP Top 10 for Large Language Model Applications | ~12 hours |
-| **AVID Security** | `avid_security` | AI Vulnerability Database - Security vulnerabilities | ~12 hours |
-| **AVID Ethics** | `avid_ethics` | AI Vulnerability Database - Ethical concerns | ~5 hours |
-| **AVID Performance** | `avid_performance` | AI Vulnerability Database - Performance issues | ~5 hours |
+| **[OWASP LLM Top 10](https://genai.owasp.org/llm-top-10/)** | `owasp_llm_top10` | OWASP Top 10 for Large Language Model Applications | ~8 hours |
+| **[AVID Security](https://docs.avidml.org/taxonomy/effect-sep-view/security)** | `avid_security` | AI Vulnerability Database - Security vulnerabilities | ~8 hours |
+| **[AVID Ethics](https://docs.avidml.org/taxonomy/effect-sep-view/ethics)** | `avid_ethics` | AI Vulnerability Database - Ethical concerns | ~30 minutes |
+| **[AVID Performance](https://docs.avidml.org/taxonomy/effect-sep-view/performance)** | `avid_performance` | AI Vulnerability Database - Performance issues | ~40 minutes |
 
 ### Scan Profiles for Testing
 | Profile | Benchmark ID | Duration | Probes |
 |---------|--------------|----------|---------|
-| **Quick** | `quick` | ~5 min | Essential security checks (3 specific probes) |
-| **Standard** | `standard` | ~1 hours | Standard attack vectors (5 probe categories) |
+| **Quick** | `quick` | ~5 minutes | Essential security checks (3 specific probes) |
+| **Standard** | `standard` | ~1 hour | Standard attack vectors (5 probe categories) |
 
+_Note: All the above duration estimates are calculated with a Qwen2.5 7B model deployed via vLLM on Openshift._
 ## Usage Examples
 
 ### Discover Available Benchmarks

--- a/providers.d/inline/eval/trustyai_garak.yaml
+++ b/providers.d/inline/eval/trustyai_garak.yaml
@@ -5,6 +5,7 @@ pip_packages:
 api_dependencies:
   - inference
   - files
+  - benchmarks
 optional_api_dependencies:
   - safety
   - shields

--- a/run-with-safety.yaml
+++ b/run-with-safety.yaml
@@ -4,6 +4,7 @@ apis:
   - inference
   - eval
   - files
+  - benchmarks
   - safety
   - telemetry
 providers:

--- a/run.yaml
+++ b/run.yaml
@@ -4,6 +4,7 @@ apis:
   - inference
   - eval
   - files
+  - benchmarks
 providers:
   inference:
     - provider_id: vllm

--- a/src/llama_stack_provider_trustyai_garak/config.py
+++ b/src/llama_stack_provider_trustyai_garak/config.py
@@ -61,7 +61,7 @@ class GarakScanConfig(BaseModel):
             "description": "OWASP Top 10 for Large Language Model Applications",
             "taxonomy_filters": ["owasp:llm"],
             # "probe_tag": "owasp:llm",
-            "timeout": 60*60*12, # TODO: Run this and update the timeout
+            "timeout": 60*60*12,
             "documentation": "https://genai.owasp.org/llm-top-10/",
             "taxonomy": "owasp"
         },
@@ -70,7 +70,7 @@ class GarakScanConfig(BaseModel):
             "description": "AI Vulnerability and Incident Database - Security vulnerabilities",
             "taxonomy_filters": ["avid-effect:security"],
             # "probe_tag": "avid-effect:security",
-            "timeout": 60*60*12, # TODO: Run this and update the timeout
+            "timeout": 60*60*12,
             "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/security",
             "taxonomy": "avid-effect"
         },
@@ -79,7 +79,7 @@ class GarakScanConfig(BaseModel):
             "description": "AI Vulnerability and Incident Database - Ethical concerns",
             "taxonomy_filters": ["avid-effect:ethics"],
             # "probe_tag": "avid-effect:ethics",
-            "timeout": 60*60*5, # TODO: Run this and update the timeout
+            "timeout": 60*60*1,
             "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/ethics",
             "taxonomy": "avid-effect"
         },
@@ -88,7 +88,7 @@ class GarakScanConfig(BaseModel):
             "description": "AI Vulnerability and Incident Database - Performance issues",
             "taxonomy_filters": ["avid-effect:performance"],
             # "probe_tag": "avid-effect:performance",
-            "timeout": 60*60*5, # TODO: Run this and update the timeout
+            "timeout": 60*60*1,
             "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/performance",
             "taxonomy": "avid-effect"
         }

--- a/src/llama_stack_provider_trustyai_garak/config.py
+++ b/src/llama_stack_provider_trustyai_garak/config.py
@@ -62,7 +62,8 @@ class GarakScanConfig(BaseModel):
             "taxonomy_filters": ["owasp:llm"],
             # "probe_tag": "owasp:llm",
             "timeout": 60*60*12, # TODO: Run this and update the timeout
-            "documentation": "https://genai.owasp.org/llm-top-10/"
+            "documentation": "https://genai.owasp.org/llm-top-10/",
+            "taxonomy": "owasp"
         },
         "avid_security": {
             "name": "AVID Security Taxonomy",
@@ -70,7 +71,8 @@ class GarakScanConfig(BaseModel):
             "taxonomy_filters": ["avid-effect:security"],
             # "probe_tag": "avid-effect:security",
             "timeout": 60*60*12, # TODO: Run this and update the timeout
-            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/security"
+            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/security",
+            "taxonomy": "avid-effect"
         },
         "avid_ethics": {
             "name": "AVID Ethics Taxonomy", 
@@ -78,7 +80,8 @@ class GarakScanConfig(BaseModel):
             "taxonomy_filters": ["avid-effect:ethics"],
             # "probe_tag": "avid-effect:ethics",
             "timeout": 60*60*5, # TODO: Run this and update the timeout
-            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/ethics"
+            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/ethics",
+            "taxonomy": "avid-effect"
         },
         "avid_performance": {
             "name": "AVID Performance Taxonomy",
@@ -86,7 +89,8 @@ class GarakScanConfig(BaseModel):
             "taxonomy_filters": ["avid-effect:performance"],
             # "probe_tag": "avid-effect:performance",
             "timeout": 60*60*5, # TODO: Run this and update the timeout
-            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/performance"
+            "documentation": "https://docs.avidml.org/taxonomy/effect-sep-view/performance",
+            "taxonomy": "avid-effect"
         }
     }
 


### PR DESCRIPTION
This PR does two things :

- Fix bug to allow reusing previously registered benchmarks (even after app restart). The fix is to use `benchmarks` API to get benchmark instead of in-memory benchmarks dict.
- In addition to the mandatory cli options as we have now, allow all other cli params for advanced users.