### PR TITLE
Add tls + optimize httpx client creation + fix register_benchmark bug 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,11 @@
 [project]
 name = "llama-stack-provider-trustyai-garak"
-version = "0.0.1"
+version = "0.1.0"
 description = "OOT provider for garak redteam"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "llama-stack",
+    "llama-stack>=0.2.15",
     "fastapi",
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",
@@ -14,7 +14,7 @@ dependencies = [
     "uvicorn",
     "ipykernel",
     "httpx[http2]",
-    "garak",
+    "garak==0.12.0",
 ]
 
 [project.optional-dependencies]

--- a/run-with-safety.yaml
+++ b/run-with-safety.yaml
@@ -24,6 +24,7 @@ providers:
         timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
         max_workers: ${env.GARAK_MAX_WORKERS:=5} # 5 max workers for shield scanning
         max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
+        tls_verify: ${env.GARAK_TLS_VERIFY:=true}
   files:
     - provider_id: meta-reference-files
       provider_type: inline::localfs

--- a/run.yaml
+++ b/run.yaml
@@ -11,9 +11,9 @@ providers:
       provider_type: remote::vllm
       config:
         url: ${env.VLLM_URL}
-        # max_tokens: ${env.VLLM_MAX_TOKENS:4096}
+        max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
         api_token: ${env.VLLM_API_TOKEN:fake}
-        # tls_verify: ${env.VLLM_TLS_VERIFY:false}
+        tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
     - provider_id: trustyai_garak
       provider_type: inline::trustyai_garak
@@ -21,6 +21,7 @@ providers:
         base_url: ${env.BASE_URL:=http://localhost:8321/v1} # llama-stack service base url
         timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
         max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
+        tls_verify: ${env.GARAK_TLS_VERIFY:=true}
   files:
     - provider_id: meta-reference-files
       provider_type: inline::localfs

--- a/src/llama_stack_provider_trustyai_garak/garak_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/garak_eval.py
@@ -132,12 +132,6 @@ class GarakEvalAdapter(Eval, BenchmarksProtocolPrivate):
     
     async def register_benchmark(self, benchmark: Benchmark) -> None:
         """Register a benchmark by checking if it's a pre-defined scan profile or compliance framework profile"""
-        stored_benchmark = await self.get_benchmark(benchmark.identifier)
-        if stored_benchmark:
-            logger.warning(f"Benchmark '{benchmark.identifier}' already registered. Skipping registration.")
-            if benchmark.identifier not in self.benchmarks:
-                self.benchmarks[benchmark.identifier] = stored_benchmark
-            return
         
         if benchmark.identifier in self.scan_config.SCAN_PROFILES | self.scan_config.FRAMEWORK_PROFILES:
             logger.warning(f"Benchmark '{benchmark.identifier}' is a pre-defined scan profile or compliance framework profile. It is not recommended to register it as a custom benchmark.")
@@ -239,6 +233,7 @@ class GarakEvalAdapter(Eval, BenchmarksProtocolPrivate):
 
             env = os.environ.copy()
             env["GARAK_LOG_FILE"] = str(scan_log_file)
+            env["GARAK_TLS_VERIFY"] = str(self._config.tls_verify)
 
             process = await asyncio.create_subprocess_exec(*cmd, 
                                                            stdout=asyncio.subprocess.PIPE, 


### PR DESCRIPTION
This PR does 3 things (sorry for multiple changes):

- Adds tls config to httpx client (can be bool or valid path)
- Optimized httpx client creation by storing in a global cache to share by each process. This is to fix the multiprocess pickling error as it pickles the instance httpx client variable.
- benchmarks get api throws error if no benchmark found, so removed the logic for get_benchmark before registering 