### PR TITLE
get token with k8s client instead of `oc whoami`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 ]
 keywords = ["llama-stack", "garak", "red-teaming", "security", "ai-safety"]
 dependencies = [
-    "llama-stack==0.2.15",
+    "llama-stack>=0.2.15",
     "fastapi",
     "opentelemetry-api",
     "opentelemetry-exporter-otlp",

--- a/src/llama_stack_provider_trustyai_garak/__init__.py
+++ b/src/llama_stack_provider_trustyai_garak/__init__.py
@@ -1,12 +1,12 @@
 import logging
 from typing import Dict, Optional
 
+from .provider import get_provider_spec
 from llama_stack.apis.datatypes import Api
 from llama_stack.providers.datatypes import ProviderSpec
 from .config import GarakEvalProviderConfig, GarakRemoteConfig
 from .garak_eval import GarakEvalAdapter
 from .garak_remote_eval import GarakRemoteEvalAdapter
-from .provider import get_provider_spec
 
 # Set up logging
 logger = logging.getLogger(__name__)

--- a/src/llama_stack_provider_trustyai_garak/provider.py
+++ b/src/llama_stack_provider_trustyai_garak/provider.py
@@ -5,37 +5,26 @@ from llama_stack.providers.datatypes import (
     remote_provider_spec,
     InlineProviderSpec
 )
-from llama_stack.apis import (
-    inference, 
-    files, 
-    safety,
-    telemetry,
-    shields,
-    benchmarks
-    )
-from typing import List
 
-
-def get_provider_spec() -> List[ProviderSpec]:
-    return [
-        remote_provider_spec(
+def get_provider_spec() -> ProviderSpec:
+    return remote_provider_spec(
             api=Api.eval,
             adapter=AdapterSpec(
                 adapter_type="trustyai_garak",
                 module="llama_stack_provider_trustyai_garak",
                 pip_packages=["garak", "kfp", "kfp-kubernetes", "kfp-server-api", "boto3"],
-                config_class="config.GarakRemoteConfig",
+                config_class="llama_stack_provider_trustyai_garak.config.GarakRemoteConfig",
             ),
-            api_dependencies=[inference, files, benchmarks],
-            optional_api_dependencies=[safety, telemetry, shields]
-        ),
-        InlineProviderSpec(
-            api=Api.eval,
-            provider_type="inline::trustyai_garak",
-            pip_packages=["garak"],
-            config_class="config.GarakEvalProviderConfig",
-            module="llama_stack_provider_trustyai_garak",
-            api_dependencies=[inference, files, benchmarks],
-            optional_api_dependencies=[safety, telemetry, shields]
+            api_dependencies=[Api.inference, Api.files, Api.benchmarks, Api.safety, Api.telemetry, Api.shields],
+            # optional_api_dependencies=[]
         )
-    ]
+    #     InlineProviderSpec(
+    #         api=Api.eval,
+    #         provider_type="inline::trustyai_garak",
+    #         pip_packages=["garak"],
+    #         config_class="llama_stack_provider_trustyai_garak.config.GarakEvalProviderConfig",
+    #         module="llama_stack_provider_trustyai_garak",
+    #         api_dependencies=[Api.inference, Api.files, Api.benchmarks],
+    #         optional_api_dependencies=[Api.safety, Api.telemetry, Api.shields]
+    #     )
+    # ]


### PR DESCRIPTION
This PR replaces `oc whoami -t` with `load_kube_config` to get token. This is to move towards standardizing the client creation.