### PR TITLE
Updated type for `verify_ssl` to be str for remote exec fix

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -20,4 +20,4 @@ ENV XDG_CACHE_HOME=/tmp/.cache
 ENV XDG_DATA_HOME=/tmp/.local/share
 ENV XDG_CONFIG_HOME=/tmp/.config
 
-USER 1001
+# USER 1001

--- a/src/llama_stack_provider_trustyai_garak/config.py
+++ b/src/llama_stack_provider_trustyai_garak/config.py
@@ -1,5 +1,5 @@
 from llama_stack.schema_utils import json_schema_type
-from typing import Dict, Any
+from typing import Dict, Any, Union
 from pydantic import BaseModel, Field, field_validator
 from pathlib import Path
 
@@ -20,7 +20,7 @@ class GarakEvalProviderConfig(BaseModel):
     timeout: int = 60*60*3 # default timeout for garak scan
     max_workers: int = 5 # default max workers for shield scanning
     max_concurrent_jobs: int = 5 # max concurrent garak scans
-    tls_verify: bool | str = Field(
+    tls_verify: Union[bool, str] = Field(
         default=True,
         description="Whether to verify TLS certificates. Can be a boolean or a path to a CA certificate file.",
     )
@@ -55,7 +55,7 @@ class GarakEvalProviderConfig(BaseModel):
         timeout: int = "${env.GARAK_TIMEOUT:=10800}",
         max_workers: int = "${env.GARAK_MAX_WORKERS:=5}",
         max_concurrent_jobs: int = "${env.GARAK_MAX_CONCURRENT_JOBS:=5}",
-        tls_verify: bool | str = "${env.GARAK_TLS_VERIFY:=true}",
+        tls_verify: Union[bool, str] = "${env.GARAK_TLS_VERIFY:=true}",
         **kwargs,
     ) -> Dict[str, Any]:
 

--- a/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
@@ -308,7 +308,7 @@ class GarakRemoteEvalAdapter(Eval, BenchmarksProtocolPrivate):
                     "timeout_seconds": int(scan_profile_config.get("timeout", self._config.timeout)),
                     "max_retries": int(benchmark_metadata.get("max_retries", 3)),
                     "use_gpu": benchmark_metadata.get("use_gpu", False),
-                    "verify_ssl": self._verify_ssl,
+                    "verify_ssl": str(self._verify_ssl),
                 },
                 run_name=f"garak-{benchmark_id.split('::')[-1]}-{job_id.removeprefix(JOB_ID_PREFIX)}",
                 namespace=self._config.kubeflow_config.namespace,

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
@@ -146,7 +146,7 @@ def parse_results(
     llama_stack_url: str,
     eval_threshold: float,
     job_id: str,
-    verify_ssl: bool | str,
+    verify_ssl: str,
 ):
 
     """Parse results and provide analysis"""
@@ -159,6 +159,15 @@ def parse_results(
     from llama_stack.apis.eval import EvaluateResponse
     from llama_stack_provider_trustyai_garak.errors import GarakValidationError
     from typing import List, Dict, Any
+
+    # Parse verify_ssl string back to bool or keep as path
+    if verify_ssl.lower() in ("true", "1", "yes", "on"):
+        parsed_verify_ssl = True
+    elif verify_ssl.lower() in ("false", "0", "no", "off"):
+        parsed_verify_ssl = False
+    else:
+        # It's a path to a certificate file
+        parsed_verify_ssl = verify_ssl
 
     client = LlamaStackClient(base_url=llama_stack_url)
     
@@ -270,7 +279,7 @@ def parse_results(
                 aws_secret_access_key=os.environ.get('AWS_SECRET_ACCESS_KEY'),
                 region_name=os.environ.get('AWS_DEFAULT_REGION', 'us-east-1'),
                 use_ssl=s3_endpoint.startswith('https'),
-                verify=verify_ssl,
+                verify=parsed_verify_ssl,
             )
         except Exception as e:
             print(f"Error creating S3 client: {e}")

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
@@ -1,4 +1,4 @@
-from typing import List, Union
+from typing import List
 from kfp import dsl, kubernetes
 from .components import validate_inputs, garak_scan, parse_results
 
@@ -25,7 +25,7 @@ def garak_scan_pipeline(
     timeout_seconds: int,
     max_retries: int = 3,
     use_gpu: bool = False,
-    verify_ssl: Union[bool, str] = True,
+    verify_ssl: str = "True",
     resource_config: dict = {}, # TODO: parameterize gpu and cpu resource limits
     ):
 


### PR DESCRIPTION
Refactor SSL verification handling in Garak remote pipeline components

- Modified `parse_results` function to parse `verify_ssl` as a string and handle it accordingly.
- Adjusted `garak_scan_pipeline` to accept `verify_ssl` as a string.
- Changed `verify_ssl` assignment in `GarakRemoteEvalAdapter` to convert it to a string for consistency.
- Commented out the USER directive in the Containerfile to make it work with latest LLS versions.