### PR TITLE
Remove 'Api.telemetry' from the optional API dependencies in both the inline and remote provider specifications.

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/inline/provider.py
+++ b/src/llama_stack_provider_trustyai_garak/inline/provider.py
@@ -12,5 +12,5 @@ def get_provider_spec() -> ProviderSpec:
             config_class="llama_stack_provider_trustyai_garak.config.GarakEvalProviderConfig",
             module="llama_stack_provider_trustyai_garak.inline",
             api_dependencies=[Api.inference, Api.files, Api.benchmarks],
-            optional_api_dependencies=[Api.safety, Api.telemetry, Api.shields]
+            optional_api_dependencies=[Api.safety, Api.shields]
         )

--- a/src/llama_stack_provider_trustyai_garak/remote/provider.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/provider.py
@@ -10,7 +10,7 @@ def get_provider_spec() -> ProviderSpec:
             provider_type="remote::trustyai_garak",
             config_class="llama_stack_provider_trustyai_garak.config.GarakRemoteConfig",
             api_dependencies=[Api.inference, Api.files, Api.benchmarks],
-            optional_api_dependencies=[Api.safety, Api.telemetry, Api.shields],
+            optional_api_dependencies=[Api.safety, Api.shields],
             module="llama_stack_provider_trustyai_garak.remote",
             pip_packages=["garak", "kfp", "kfp-kubernetes", "kfp-server-api", "boto3"],
             adapter_type="trustyai_garak",

--- a/tests/test_remote_provider.py
+++ b/tests/test_remote_provider.py
@@ -31,7 +31,7 @@ class TestRemoteProvider:
         assert spec.module == "llama_stack_provider_trustyai_garak.remote"
         for api in [Api.inference, Api.files, Api.benchmarks]:
             assert api in spec.api_dependencies, f"{api} not found in api_dependencies"
-        for api in [Api.safety, Api.shields, Api.telemetry]:
+        for api in [Api.safety, Api.shields]:
             assert api in spec.optional_api_dependencies, f"{api} not found in optional_api_dependencies"
 
 


### PR DESCRIPTION
Closes #57 