### PR TITLE
Update kubeflow config to align with ragas provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ pip install -e .
 ### 1. Configure Environment
 
 ```bash
+# Model serving endpoint
 export VLLM_URL="http://your-model-endpoint/v1"
 export INFERENCE_MODEL="your-model-name"
+
+# Llama Stack endpoint (for inline: local, for remote: accessible from KFP pods)
+export LLAMA_STACK_URL="http://localhost:8321"
 ```
 
 ### 2. Start Server
@@ -155,24 +159,29 @@ report = requests.get(f"http://localhost:8321/v1/openai/v1/files/{scan_html_id}/
 ### Setup
 
 ```bash
-# KFP Configuration
+# Llama Stack URL (must be accessible from Kubeflow pods - use ngrok if local)
+export LLAMA_STACK_URL="https://your-llama-stack-url.ngrok.io"
+
+# Kubeflow Configuration
 export KUBEFLOW_PIPELINES_ENDPOINT="https://your-kfp-endpoint"
 export KUBEFLOW_NAMESPACE="your-namespace"
-export KUBEFLOW_EXPERIMENT_NAME="trustyai-garak-scans"
-export KUBEFLOW_BASE_IMAGE="quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu" # for gpu - "quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:gpu"
+export KUBEFLOW_BASE_IMAGE="quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:latest"
+export KUBEFLOW_RESULTS_S3_PREFIX="s3://garak-results/scans"  # S3 path: bucket/prefix
+export KUBEFLOW_S3_CREDENTIALS_SECRET_NAME="aws-connection-pipeline-artifacts"  # K8s secret name
+export KUBEFLOW_PIPELINES_TOKEN=""  # Optional: If not set, uses kubeconfig
 
-# S3 Configuration (for artifacts)
+# S3 Configuration (for server-side S3 access to retrieve results)
+# These are also stored in the Kubernetes secret specified above for pod access
 export AWS_ACCESS_KEY_ID="your-key"
 export AWS_SECRET_ACCESS_KEY="your-secret"
-export AWS_S3_ENDPOINT="https://your-s3-endpoint"
-export AWS_S3_BUCKET="pipeline-artifacts"
+export AWS_S3_ENDPOINT="https://your-s3-endpoint" # if using MinIO
 export AWS_DEFAULT_REGION="us-east-1"
 
 # Start server
 llama stack run run-remote.yaml
 ```
 
-_Note: If you're running Llama Stack server locally, make sure `BASE_URL` in run-remote*.yaml is accessible from KFP pods (you can use [ngrok](https://ngrok.com/) to create an accessible endpoint for your local Llama stack service)._
+_Note: For remote execution, `LLAMA_STACK_URL` must be accessible from KFP pods. If running locally, use [ngrok](https://ngrok.com/) to create an accessible endpoint._
 
 ### Usage
 
@@ -194,7 +203,7 @@ providers:
   eval:
     - provider_id: trustyai_garak
       config:
-        base_url: ${env.BASE_URL:=http://localhost:8321/v1}
+        llama_stack_url: ${env.LLAMA_STACK_URL:=http://localhost:8321}
         timeout: ${env.GARAK_TIMEOUT:=10800}
         max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5}
         max_workers: ${env.GARAK_MAX_WORKERS:=5}
@@ -204,9 +213,9 @@ providers:
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `BASE_URL` | `http://localhost:8321/v1` | Llama Stack service URL |
+| `LLAMA_STACK_URL` | `http://localhost:8321/v1` | Llama Stack API URL |
 | `GARAK_TIMEOUT` | `10800` | Max scan timeout (seconds) |
-| `GARAK_MAX_CONCURRENT_JOBS` | `5` | Max concurrent scans |
+| `GARAK_MAX_CONCURRENT_JOBS` | `5` | Max concurrent scans (inline only) |
 | `GARAK_MAX_WORKERS` | `5` | Shield scanning parallelism |
 
 ## Deployment Modes

--- a/run-remote-safety.yaml
+++ b/run-remote-safety.yaml
@@ -17,19 +17,19 @@ providers:
         api_token: ${env.VLLM_API_TOKEN:fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
-    - provider_id: trustyai_garak
+    - provider_id: trustyai_garak_remote
       provider_type: remote::trustyai_garak
       module: llama_stack_provider_trustyai_garak
       config:
-        base_url: ${env.BASE_URL:=https://f70b2fb955e7.ngrok-free.app/v1} # llama-stack service base url (should be accessible from kf pods)
-        timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
-        max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
+        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL}
         tls_verify: ${env.GARAK_TLS_VERIFY:=true}
         kubeflow_config:
-          pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=https://ds-pipeline-dspa-model-namespace.apps.rosa.y1m4j9o2e1n6b9l.r6mx.p3.openshiftapps.com}
-          namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
-          experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
-          base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
+          results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX}
+          s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME}
+          pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT}
+          namespace: ${env.KUBEFLOW_NAMESPACE}
+          base_image: ${env.KUBEFLOW_BASE_IMAGE}
+          pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=}
   files:
     - provider_id: meta-reference-files
       provider_type: inline::localfs
@@ -69,37 +69,37 @@ registered_resources:
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: quick
     - benchmark_id: trustyai_garak::standard
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: standard
     - benchmark_id: trustyai_garak::owasp_llm_top10
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: owasp_llm_top10
     - benchmark_id: trustyai_garak::avid_security
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_security
     - benchmark_id: trustyai_garak::avid_ethics
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_ethics
     - benchmark_id: trustyai_garak::avid_performance
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_performance
   shields:
   - shield_id: Prompt-Guard-86M

--- a/run-remote.yaml
+++ b/run-remote.yaml
@@ -15,19 +15,19 @@ providers:
         api_token: ${env.VLLM_API_TOKEN:fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
-    - provider_id: trustyai_garak
+    - provider_id: trustyai_garak_remote
       provider_type: remote::trustyai_garak
       module: llama_stack_provider_trustyai_garak
       config:
-        base_url: ${env.BASE_URL:=https://f70b2fb955e7.ngrok-free.app/v1} # llama-stack service base url (should be accessible from kf pods)
-        timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
-        max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
+        llama_stack_url: ${env.KUBEFLOW_LLAMA_STACK_URL} # should be accessible from kf pods
         tls_verify: ${env.GARAK_TLS_VERIFY:=true}
         kubeflow_config:
-          pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT:=https://ds-pipeline-dspa-model-namespace.apps.rosa.y1m4j9o2e1n6b9l.r6mx.p3.openshiftapps.com}
-          namespace: ${env.KUBEFLOW_NAMESPACE:=model-namespace}
-          experiment_name: ${env.KUBEFLOW_EXPERIMENT_NAME:=trustyai-garak-scans}
-          base_image: ${env.KUBEFLOW_BASE_IMAGE:=quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu}
+          results_s3_prefix: ${env.KUBEFLOW_RESULTS_S3_PREFIX}
+          s3_credentials_secret_name: ${env.KUBEFLOW_S3_CREDENTIALS_SECRET_NAME}
+          pipelines_endpoint: ${env.KUBEFLOW_PIPELINES_ENDPOINT}
+          namespace: ${env.KUBEFLOW_NAMESPACE}
+          base_image: ${env.KUBEFLOW_BASE_IMAGE}
+          pipelines_api_token: ${env.KUBEFLOW_PIPELINES_TOKEN:=} # if not set, uses kubeconfig
   files:
     - provider_id: meta-reference-files
       provider_type: inline::localfs
@@ -62,37 +62,37 @@ registered_resources:
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: quick
     - benchmark_id: trustyai_garak::standard
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: standard
     - benchmark_id: trustyai_garak::owasp_llm_top10
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: owasp_llm_top10
     - benchmark_id: trustyai_garak::avid_security
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_security
     - benchmark_id: trustyai_garak::avid_ethics
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_ethics
     - benchmark_id: trustyai_garak::avid_performance
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_remote
       provider_benchmark_id: avid_performance
 server:
   port: 8321

--- a/run-with-safety.yaml
+++ b/run-with-safety.yaml
@@ -16,13 +16,12 @@ providers:
         api_token: ${env.VLLM_API_TOKEN:fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
-    - provider_id: trustyai_garak
+    - provider_id: trustyai_garak_inline
       provider_type: inline::trustyai_garak
       module: llama_stack_provider_trustyai_garak
       config:
-        base_url: ${env.BASE_URL:=http://localhost:8321/v1} # llama-stack service base url
+        llama_stack_url: ${env.LLAMA_STACK_URL:=http://localhost:8321}
         timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
-        max_workers: ${env.GARAK_MAX_WORKERS:=5} # 5 max workers for shield scanning
         max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
         tls_verify: ${env.GARAK_TLS_VERIFY:=true}
   files:
@@ -64,37 +63,37 @@ registered_resources:
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: quick
     - benchmark_id: trustyai_garak::standard
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: standard
     - benchmark_id: trustyai_garak::owasp_llm_top10
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: owasp_llm_top10
     - benchmark_id: trustyai_garak::avid_security
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_security
     - benchmark_id: trustyai_garak::avid_ethics
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_ethics
     - benchmark_id: trustyai_garak::avid_performance
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_performance
   shields:
   - shield_id: Prompt-Guard-86M

--- a/run.yaml
+++ b/run.yaml
@@ -15,11 +15,11 @@ providers:
         api_token: ${env.VLLM_API_TOKEN:fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
-    - provider_id: trustyai_garak
+    - provider_id: trustyai_garak_inline
       provider_type: inline::trustyai_garak
       module: llama_stack_provider_trustyai_garak
       config:
-        base_url: ${env.BASE_URL:=http://localhost:8321/v1} # llama-stack service base url
+        llama_stack_url: ${env.LLAMA_STACK_URL:=http://localhost:8321}
         timeout: ${env.GARAK_TIMEOUT:=10800} # 3 hours max timeout for garak scan
         max_concurrent_jobs: ${env.GARAK_MAX_CONCURRENT_JOBS:=5} # 5 max concurrent garak scans
         tls_verify: ${env.GARAK_TLS_VERIFY:=true}
@@ -57,37 +57,37 @@ registered_resources:
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: quick
     - benchmark_id: trustyai_garak::standard
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: standard
     - benchmark_id: trustyai_garak::owasp_llm_top10
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: owasp_llm_top10
     - benchmark_id: trustyai_garak::avid_security
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_security
     - benchmark_id: trustyai_garak::avid_ethics
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_ethics
     - benchmark_id: trustyai_garak::avid_performance
       dataset_id: garak
       scoring_functions:
         - garak_scoring
-      provider_id: trustyai_garak
+      provider_id: trustyai_garak_inline
       provider_benchmark_id: avid_performance
 server:
   port: 8321

--- a/src/llama_stack_provider_trustyai_garak/base_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/base_eval.py
@@ -261,12 +261,12 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
         if 'generator_options' in benchmark_metadata:
             return benchmark_metadata['generator_options']
         
-        base_url: str = self._get_base_url()
+        llama_stack_url: str = self._get_llama_stack_url()
 
         generator_options = {
             "openai": {
                 "OpenAICompatible": {
-                    "uri": base_url,
+                    "uri": llama_stack_url,
                     "model": benchmark_config.eval_candidate.model,
                     "api_key": os.getenv("OPENAICOMPATIBLE_API_KEY", "DUMMY"),
                     "suppressed_params": ["n"]
@@ -300,15 +300,20 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
             generator_options["openai"]["OpenAICompatible"].update(valid_params)
         return generator_options
     
-    def _get_base_url(self) -> str:
+    def _get_llama_stack_url(self) -> str:
+        """Get the normalized Llama Stack URL with /v1 suffix.
+        
+        Returns:
+            Llama Stack URL with /v1 suffix
+        """
         import re
 
-        base_url: str = self._config.base_url.rstrip("/")
+        llama_stack_url: str = self._config.llama_stack_url.rstrip("/")
         
-        # check if base_url ends with /v{number} and if not, add v1
-        if not re.match(r"^.*\/v\d+$", base_url):
-            base_url = f"{base_url}/v1"
-        return base_url
+        # check if URL ends with /v{number} and if not, add v1
+        if not re.match(r"^.*\/v\d+$", llama_stack_url):
+            llama_stack_url = f"{llama_stack_url}/v1"
+        return llama_stack_url
 
     async def _get_function_based_generator_options(
         self, benchmark_config: "BenchmarkConfig", benchmark_metadata: dict
@@ -324,7 +329,7 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
         """
         from llama_stack_provider_trustyai_garak import shield_scan
         
-        base_url: str = self._get_base_url()
+        llama_stack_url: str = self._get_llama_stack_url()
         
         # Map the shields to the input and output of LLM
         llm_io_shield_mapping: dict = {
@@ -361,7 +366,7 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
                     "name": f"{shield_scan.__name__}#simple_shield_orchestrator",
                     "kwargs": {
                         "model": benchmark_config.eval_candidate.model,
-                        "base_url": base_url,
+                        "base_url": llama_stack_url,
                         "llm_io_shield_mapping": llm_io_shield_mapping,
                         "max_workers": self._config.max_workers
                     }

--- a/src/llama_stack_provider_trustyai_garak/constants.py
+++ b/src/llama_stack_provider_trustyai_garak/constants.py
@@ -1,0 +1,5 @@
+# Kubeflow ConfigMap keys and defaults for base image resolution
+GARAK_PROVIDER_IMAGE_CONFIGMAP_NAME = "trustyai-service-operator-config"
+GARAK_PROVIDER_IMAGE_CONFIGMAP_KEY = "garak-provider-image" # from https://github.com/opendatahub-io/opendatahub-operator/pull/2567
+DEFAULT_GARAK_PROVIDER_IMAGE = "quay.io/rh-ee-spandraj/trustyai-garak-provider-dsp:cpu"
+KUBEFLOW_CANDIDATE_NAMESPACES = ["redhat-ods-applications", "opendatahub"]

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
@@ -1,19 +1,13 @@
 from typing import List
 from kfp import dsl, kubernetes
 from .components import validate_inputs, garak_scan, parse_results
+from dotenv import load_dotenv
+import logging
+import os
 
-# def add_gpu_toleration(task: dsl.PipelineTask, accelerator_type: str, accelerator_limit: int):
-#     print(f"Adding GPU tolerations: {accelerator_type}({accelerator_limit})")
-#     task.set_accelerator_type(accelerator=accelerator_type)
-#     task.set_accelerator_limit(accelerator_limit)
-#     kubernetes.add_toleration(task, key=accelerator_type, operator="Exists", effect="NoSchedule")
-
-# def add_resource_limits(task: dsl.PipelineTask, resource_config: dict):
-#     print(f"Adding resource limits: {resource_config}")
-#     task.set_cpu_request(str(resource_config.get("cpu_request", "500m")))
-#     task.set_cpu_limit(str(resource_config.get("cpu_limit", "4")))
-#     task.set_memory_request(str(resource_config.get("memory_request", "2Gi")))
-#     task.set_memory_limit(str(resource_config.get("memory_limit", "6Gi")))
+load_dotenv()
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
 
 
 @dsl.pipeline()
@@ -23,6 +17,8 @@ def garak_scan_pipeline(
     job_id: str,
     eval_threshold: float,
     timeout_seconds: int,
+    s3_bucket: str,
+    s3_prefix: str = "",
     max_retries: int = 3,
     use_gpu: bool = False,
     verify_ssl: str = "True",
@@ -30,7 +26,7 @@ def garak_scan_pipeline(
     ):
 
     # AWS connection secret
-    aws_connection_secret = "aws-connection-pipeline-artifacts"
+    aws_connection_secret = os.environ.get('KUBEFLOW_S3_CREDENTIALS_SECRET_NAME', 'aws-connection-pipeline-artifacts')
     secret_key_to_env = {
         "AWS_ACCESS_KEY_ID": "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY": "AWS_SECRET_ACCESS_KEY",
@@ -70,6 +66,8 @@ def garak_scan_pipeline(
                     eval_threshold=eval_threshold,
                     job_id=job_id,
                     verify_ssl=verify_ssl,
+                    s3_bucket=s3_bucket,
+                    s3_prefix=s3_prefix,
                 )
                 parse_task_gpu.set_caching_options(False)
                 
@@ -78,8 +76,6 @@ def garak_scan_pipeline(
                     secret_name=aws_connection_secret,
                     secret_key_to_env=secret_key_to_env,
                 )
-            # add_gpu_toleration(scan_task_gpu, "nvidia.com/gpu", 1)
-            # add_resource_limits(scan_task_gpu, resource_config)
         
         with dsl.Else(name="USE_CPU"):
             scan_task_cpu: dsl.PipelineTask = garak_scan(
@@ -90,7 +86,6 @@ def garak_scan_pipeline(
             )
             scan_task_cpu.after(validate_task)
             scan_task_cpu.set_caching_options(False)
-            # add_resource_limits(scan_task_cpu, resource_config)
 
             # # Step 3: Parse the scan results ONLY if scan succeeds
             with dsl.If(scan_task_cpu.outputs['success'] == True, name="cpu_scan_succeeded"):
@@ -100,6 +95,8 @@ def garak_scan_pipeline(
                     eval_threshold=eval_threshold,
                     job_id=job_id,
                     verify_ssl=verify_ssl,
+                    s3_bucket=s3_bucket,
+                    s3_prefix=s3_prefix,
                 )
                 parse_task_cpu.set_caching_options(False)
                 
@@ -108,29 +105,3 @@ def garak_scan_pipeline(
                     secret_name=aws_connection_secret,
                     secret_key_to_env=secret_key_to_env,
                 )
-
-        
-        ## TODO: this is not working as expected
-        # merged_file_id_mapping = dsl.OneOf(
-        #     scan_task_gpu.outputs['file_id_mapping'], 
-        #     scan_task_cpu.outputs['file_id_mapping']
-        # )
-        # merged_success = dsl.OneOf(
-        #     scan_task_gpu.outputs['success'],
-        #     scan_task_cpu.outputs['success']
-        # )
-        
-        # with dsl.If(merged_success == True, name="scan_succeeded"):
-        #     parse_task:dsl.PipelineTask = parse_results(
-        #         file_id_mapping=merged_file_id_mapping,
-        #         llama_stack_url=llama_stack_url,
-        #         eval_threshold=eval_threshold,
-        #         job_id=job_id,
-        #     )
-        #     parse_task.set_caching_options(False)
-            
-        #     kubernetes.use_secret_as_env(
-        #         parse_task,
-        #         secret_name=aws_connection_secret,
-        #         secret_key_to_env=secret_key_to_env,
-        #     )

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/utils.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/utils.py
@@ -1,0 +1,19 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _load_kube_config():
+    from kubernetes import config
+    from kubernetes.client.configuration import Configuration
+
+    kube_config = Configuration()
+
+    try:
+        config.load_incluster_config(client_configuration=kube_config)
+        logger.info("Loaded in-cluster Kubernetes configuration")
+    except config.ConfigException:
+        config.load_kube_config(client_configuration=kube_config)
+        logger.info("Loaded Kubernetes configuration from kubeconfig file")
+
+    return kube_config

--- a/tests/test_inline_provider.py
+++ b/tests/test_inline_provider.py
@@ -48,9 +48,9 @@ class TestInlineProvider:
                     impl.initialize.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_provider_impl_with_base_url(self):
-        """Test provider implementation with base_url from config"""
-        config = GarakInlineConfig(base_url="https://custom.api.com")
+    async def test_get_provider_impl_with_llama_stack_url(self):
+        """Test provider implementation with llama_stack_url from config"""
+        config = GarakInlineConfig(llama_stack_url="https://custom.api.com")
         
         # Provide required mock dependencies
         mock_deps = {
@@ -63,7 +63,7 @@ class TestInlineProvider:
                 with patch.object(GarakInlineEvalAdapter, '_get_all_probes', return_value=set()):
                     impl = await get_provider_impl(config, mock_deps)
                     
-                    assert impl._config.base_url == "https://custom.api.com"
+                    assert impl._config.llama_stack_url == "https://custom.api.com"
 
     @pytest.mark.asyncio
     async def test_get_provider_impl_error_handling(self):

--- a/tests/test_remote_provider.py
+++ b/tests/test_remote_provider.py
@@ -47,9 +47,10 @@ class TestRemoteAdapterCreation:
     async def test_get_adapter_impl_success(self):
         """Test successful adapter implementation creation"""
         kubeflow_config = KubeflowConfig(
+            results_s3_prefix="garak-results/scans",
+            s3_credentials_secret_name="aws-connection-pipeline-artifacts",
             pipelines_endpoint="https://kfp.example.com",
             namespace="default",
-            experiment_name="test",
             base_image="test:latest"
         )
         config = GarakRemoteConfig(kubeflow_config=kubeflow_config)
@@ -74,9 +75,10 @@ class TestRemoteAdapterCreation:
     async def test_get_adapter_impl_with_optional_deps(self):
         """Test adapter implementation with optional safety and shields dependencies"""
         kubeflow_config = KubeflowConfig(
+            results_s3_prefix="garak-results/scans",
+            s3_credentials_secret_name="aws-connection-pipeline-artifacts",
             pipelines_endpoint="https://kfp.example.com",
             namespace="default",
-            experiment_name="test",
             base_image="test:latest"
         )
         config = GarakRemoteConfig(kubeflow_config=kubeflow_config)
@@ -102,9 +104,10 @@ class TestRemoteAdapterCreation:
     async def test_get_adapter_impl_error_handling(self):
         """Test error handling in adapter implementation creation"""
         kubeflow_config = KubeflowConfig(
+            results_s3_prefix="garak-results/scans",
+            s3_credentials_secret_name="aws-connection-pipeline-artifacts",
             pipelines_endpoint="https://kfp.example.com",
             namespace="default",
-            experiment_name="test",
             base_image="test:latest"
         )
         config = GarakRemoteConfig(kubeflow_config=kubeflow_config)
@@ -130,9 +133,10 @@ class TestGarakRemoteEvalAdapter:
     def adapter_config(self):
         """Create test configuration"""
         kubeflow_config = KubeflowConfig(
+            results_s3_prefix="garak-results/scans",
+            s3_credentials_secret_name="aws-connection-pipeline-artifacts",
             pipelines_endpoint="https://kfp.example.com",
             namespace="test-namespace",
-            experiment_name="test-experiment",
             base_image="test:latest"
         )
         return GarakRemoteConfig(


### PR DESCRIPTION
Aligned the Garak provider's Kubeflow configuration with the Ragas provider so that same KF specific env vars can be used for both providers.

- [x] Please review #59 before this one, since this PR includes changes built on top of it.

## Summary by Sourcery

Align Garak provider configuration and code structure with Ragas provider by updating Kubeflow settings, and unifying environment variables

Enhancements:
- Refactor provider configuration: replace base_url with llama_stack_url, create GarakInlineConfig and GarakRemoteConfig from a shared base, and add pipelines_api_token
- Parse results_s3_prefix into s3_bucket and s3_prefix for remote execution and propagate these through pipeline components
- Update provider templates and YAML examples to use unified env vars (LLAMA_STACK_URL, KUBEFLOW_RESULTS_S3_PREFIX, pipelines_api_token) and separate inline/remote provider IDs

Documentation:
- Update README and run-*.yaml templates to reflect new environment variable names and configuration fields

Tests:
- Adjust tests to reference GarakInlineConfig and validate updated configuration behavior