### PR TITLE
Create LLS Client with TLS support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ export LLAMA_STACK_URL="https://your-llama-stack-url.ngrok.io"
 # Kubeflow Configuration
 export KUBEFLOW_PIPELINES_ENDPOINT="https://your-kfp-endpoint"
 export KUBEFLOW_NAMESPACE="your-namespace"
-export KUBEFLOW_BASE_IMAGE="quay.io/rh-ee-spandraj/trustyai-garak-lls-provider-dsp:latest"
+export KUBEFLOW_BASE_IMAGE="quay.io/rh-ee-spandraj/trustyai-lls-garak-provider-dsp:latest"
 export KUBEFLOW_RESULTS_S3_PREFIX="s3://garak-results/scans"  # S3 path: bucket/prefix
 export KUBEFLOW_S3_CREDENTIALS_SECRET_NAME="aws-connection-pipeline-artifacts"  # K8s secret name
 export KUBEFLOW_PIPELINES_TOKEN=""  # Optional: If not set, uses kubeconfig

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
@@ -38,7 +38,8 @@ def garak_scan_pipeline(
     # Step 1: Validate inputs
     validate_task: dsl.PipelineTask = validate_inputs(
         command=command,
-        llama_stack_url=llama_stack_url
+        llama_stack_url=llama_stack_url,
+        verify_ssl=verify_ssl
     )
     validate_task.set_caching_options(False)
     
@@ -51,6 +52,7 @@ def garak_scan_pipeline(
                 llama_stack_url=llama_stack_url,
                 max_retries=max_retries,
                 timeout_seconds=timeout_seconds,
+                verify_ssl=verify_ssl
             )
             scan_task_gpu.after(validate_task)
             scan_task_gpu.set_caching_options(False)
@@ -83,6 +85,7 @@ def garak_scan_pipeline(
                 llama_stack_url=llama_stack_url,
                 max_retries=max_retries,
                 timeout_seconds=timeout_seconds,
+                verify_ssl=verify_ssl
             )
             scan_task_cpu.after(validate_task)
             scan_task_cpu.set_caching_options(False)

--- a/src/llama_stack_provider_trustyai_garak/shield_scan.py
+++ b/src/llama_stack_provider_trustyai_garak/shield_scan.py
@@ -2,7 +2,6 @@
 
 from typing import List, Union
 import os
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from .compat import (
     RunShieldResponse, 
     ViolationLevel, 
@@ -10,6 +9,7 @@ from .compat import (
 )
 from llama_stack_client import LlamaStackClient
 import logging
+from llama_stack_provider_trustyai_garak.utils import get_http_client_with_tls
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,8 @@ class SimpleShieldOrchestrator:
         
         if self.llama_stack_client is None:
             try:
-                self.llama_stack_client = LlamaStackClient(base_url=base_url)
+                self.llama_stack_client = LlamaStackClient(base_url=base_url,
+                        http_client=get_http_client_with_tls(os.getenv("GARAK_TLS_VERIFY", "True")))
             except Exception as e:
                 logger.error(f"Failed to create LlamaStackClient with base_url={base_url}: {e}")
                 raise ValueError(f"Failed to initialize LlamaStack client: {e}") from e
@@ -186,7 +187,10 @@ class SimpleShieldOrchestrator:
     def close(self):
         """Close client for current process"""
         if self.llama_stack_client:
-            self.llama_stack_client.close()
+            try:
+                self.llama_stack_client.close()
+            except Exception as e:
+                logger.warning(f"Error closing client: {e}")
             self.llama_stack_client = None
     
 

--- a/src/llama_stack_provider_trustyai_garak/utils.py
+++ b/src/llama_stack_provider_trustyai_garak/utils.py
@@ -1,0 +1,24 @@
+from typing import Union
+import httpx
+
+
+def get_http_client_with_tls(tls_verify: Union[bool, str] = True) -> httpx.Client:
+    """
+    Get an HTTP client with TLS verification.
+
+    Args:
+        tls_verify: Whether to verify TLS certificates. Can be a boolean or a path to a CA certificate file.
+
+    Returns:
+        httpx.Client: An HTTP client with TLS verification.
+    """
+    if isinstance(tls_verify, str):
+        if tls_verify.lower().strip() in ("true", "1", "yes", "on", ""):
+            tls_verify = True
+        elif tls_verify.lower().strip() in ("false", "0", "no", "off"):
+            tls_verify = False
+        else:
+            tls_verify = tls_verify
+    if tls_verify is None:
+        tls_verify = True
+    return httpx.Client(verify=tls_verify)

--- a/tests/test_shield_scan.py
+++ b/tests/test_shield_scan.py
@@ -1,7 +1,7 @@
 """Tests for shield scanning functionality"""
 
 import pytest
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch, MagicMock, ANY
 
 from llama_stack_provider_trustyai_garak.shield_scan import (
     SimpleShieldOrchestrator,
@@ -33,7 +33,7 @@ class TestSimpleShieldOrchestrator:
             
             client = orchestrator._get_llama_stack_client("http://test.com")
             
-            mock_client_class.assert_called_once_with(base_url="http://test.com")
+            mock_client_class.assert_called_once_with(base_url="http://test.com", http_client=ANY)
             assert client == mock_client
             assert orchestrator.llama_stack_client == mock_client
 


### PR DESCRIPTION
This PR does 2 things - 

- Enhances the Llama Stack Client creation with TLS 
- Checks and created S3 bucket if needed before put_object.

Closes #63

## Summary by Sourcery

Add TLS-configurable HTTP client support to Llama Stack client usage and ensure S3 result buckets exist before uploads in Garak-related workflows.

New Features:
- Introduce a utility to construct an HTTP client with configurable TLS verification for use with LlamaStackClient.
- Allow Kubeflow Garak pipeline components and shield scans to configure TLS verification when connecting to the Llama Stack service.

Enhancements:
- Add S3 bucket existence checks and on-demand creation before uploading Garak results, with logging and permission handling.
- Propagate a verify_ssl parameter through Garak pipeline tasks to centralize TLS configuration for remote scans.

Documentation:
- Update the README to point to the new default Kubeflow base image name.

Tests:
- Adjust shield scan client creation tests to account for the injected HTTP client supporting TLS configuration.