### PR TITLE
🐛 Fix api_token syntax in run*.yaml files to ensure proper environment variable fallback

### DIFF
--- a/run-remote-safety.yaml
+++ b/run-remote-safety.yaml
@@ -14,7 +14,7 @@ providers:
       config:
         url: ${env.VLLM_URL}
         max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN:fake}
+        api_token: ${env.VLLM_API_TOKEN:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
     - provider_id: trustyai_garak_remote

--- a/run-remote.yaml
+++ b/run-remote.yaml
@@ -12,7 +12,7 @@ providers:
       config:
         url: ${env.VLLM_URL}
         max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN:fake}
+        api_token: ${env.VLLM_API_TOKEN:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
     - provider_id: trustyai_garak_remote

--- a/run-with-safety.yaml
+++ b/run-with-safety.yaml
@@ -13,7 +13,7 @@ providers:
       config:
         url: ${env.VLLM_URL}
         max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN:fake}
+        api_token: ${env.VLLM_API_TOKEN:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
     - provider_id: trustyai_garak_inline

--- a/run.yaml
+++ b/run.yaml
@@ -12,7 +12,7 @@ providers:
       config:
         url: ${env.VLLM_URL}
         max_tokens: ${env.VLLM_MAX_TOKENS:=4096}
-        api_token: ${env.VLLM_API_TOKEN:fake}
+        api_token: ${env.VLLM_API_TOKEN:=fake}
         tls_verify: ${env.VLLM_TLS_VERIFY:=true}
   eval:
     - provider_id: trustyai_garak_inline


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Correct environment variable default value syntax for VLLM API tokens in all run*.yaml configurations to ensure proper fallback behavior.