### PR TITLE
LLS >=0.4.0 fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "llama-stack-provider-trustyai-garak"
-version = "0.1.7"
+version = "0.1.8"
 description = "Out-Of-Tree Llama Stack provider for Garak Red-teaming"
 readme = "README.md"
 requires-python = ">=3.12"
@@ -11,7 +11,7 @@ authors = [
 ]
 keywords = ["llama-stack", "garak", "red-teaming", "security", "ai-safety"]
 dependencies = [
-    "llama-stack>=0.3.0",
+    "llama-stack[client]>=0.4.0",
     # Remote execution dependencies
     "kfp>=2.14.6",
     "kfp-kubernetes>=2.14.6",

--- a/src/llama_stack_provider_trustyai_garak/base_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/base_eval.py
@@ -13,7 +13,9 @@ from .compat import (
     Job,
     JobStatus,
     Safety,
-    Shields
+    Shields,
+    GetBenchmarkRequest,
+    RetrieveFileContentRequest,
 )
 from typing import Dict, Optional, Set, List, Any, Union
 import logging
@@ -168,7 +170,7 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
         Returns:
             Benchmark object if found, None otherwise
         """
-        return await self.benchmarks_api.get_benchmark(benchmark_id)
+        return await self.benchmarks_api.get_benchmark(GetBenchmarkRequest(benchmark_id=benchmark_id))
 
     async def register_benchmark(self, benchmark: Benchmark) -> None:
         """Register a benchmark by checking if it's a pre-defined scan profile or compliance framework.
@@ -670,7 +672,7 @@ class GarakEvalBase(Eval, BenchmarksProtocolPrivate):
         elif job.status == JobStatus.completed:
             if self._job_metadata[job_id].get(f"{prefix}scan_result.json"):
                 scan_result_file_id: str = self._job_metadata[job_id].get(f"{prefix}scan_result.json", "")
-                scan_result = await self.file_api.openai_retrieve_file_content(scan_result_file_id)
+                scan_result = await self.file_api.openai_retrieve_file_content(RetrieveFileContentRequest(file_id=scan_result_file_id))
                 return EvaluateResponse(**json.loads(scan_result.body.decode("utf-8")))
             else:
                 logger.error(f"No {prefix}scan_result.json file found for job {job_id}")

--- a/src/llama_stack_provider_trustyai_garak/compat.py
+++ b/src/llama_stack_provider_trustyai_garak/compat.py
@@ -20,12 +20,16 @@ try:
         json_schema_type,
         Benchmark,
         Benchmarks,
+        GetBenchmarkRequest,
         Eval,
         BenchmarkConfig,
         EvaluateResponse,
         Files,
         OpenAIFilePurpose,
         OpenAIFileObject,
+        ListFilesRequest,
+        RetrieveFileContentRequest,
+        UploadFileRequest,
         Safety,
         RunShieldResponse,
         ViolationLevel,
@@ -55,7 +59,7 @@ except ModuleNotFoundError:  # fallback to legacy llama_stack layout
 
     # evals
     from llama_stack.apis.benchmarks import (
-        Benchmark, Benchmarks
+        Benchmark, Benchmarks, GetBenchmarkRequest,
     )
     from llama_stack.apis.eval import (
         Eval, BenchmarkConfig, EvaluateResponse
@@ -65,7 +69,10 @@ except ModuleNotFoundError:  # fallback to legacy llama_stack layout
     from llama_stack.apis.files import (
         Files,
         OpenAIFilePurpose,
-        OpenAIFileObject
+        OpenAIFileObject,
+        ListFilesRequest,
+        RetrieveFileContentRequest,
+        UploadFileRequest,
     )
 
     # safety
@@ -104,6 +111,7 @@ __all__ = [
     # evals
     "Benchmark",
     "Benchmarks",
+    "GetBenchmarkRequest",
     "Eval",
     "BenchmarkConfig",
     "EvaluateResponse",
@@ -111,6 +119,9 @@ __all__ = [
     "Files",
     "OpenAIFilePurpose",
     "OpenAIFileObject",
+    "ListFilesRequest",
+    "RetrieveFileContentRequest",
+    "UploadFileRequest",
     # safety
     "Safety",
     "RunShieldResponse",

--- a/src/llama_stack_provider_trustyai_garak/inline/garak_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/inline/garak_eval.py
@@ -4,7 +4,9 @@ from ..compat import (
     ProviderSpec, 
     Api, 
     OpenAIFilePurpose, 
-    OpenAIFileObject, Job, JobStatus, ScoringResult
+    OpenAIFileObject, Job, JobStatus, ScoringResult,
+    UploadFileRequest,
+    RetrieveFileContentRequest,
 )
 from fastapi import UploadFile
 from typing import List, Dict, Optional, Any, Union
@@ -274,7 +276,7 @@ class GarakInlineEvalAdapter(GarakEvalBase):
                 upload_file: OpenAIFileObject = await self.file_api.openai_upload_file(
                     # file: The File object (not file name) to be uploaded.
                     file=UploadFile(file=f, filename=file.name), 
-                    purpose=purpose
+                    request=UploadFileRequest(purpose=purpose)
                 )
                 return upload_file
         else:
@@ -289,7 +291,7 @@ class GarakInlineEvalAdapter(GarakEvalBase):
         Returns:
             Tuple of (generations, score_rows_by_probe)
         """
-        report_content = await self.file_api.openai_retrieve_file_content(report_file_id)
+        report_content = await self.file_api.openai_retrieve_file_content(RetrieveFileContentRequest(file_id=report_file_id))
         if not report_content:
             return [], {}
         
@@ -306,7 +308,7 @@ class GarakInlineEvalAdapter(GarakEvalBase):
         if not avid_file_id:
             return {}
         
-        avid_content = await self.file_api.openai_retrieve_file_content(avid_file_id)
+        avid_content = await self.file_api.openai_retrieve_file_content(request=RetrieveFileContentRequest(file_id=avid_file_id))
         if not avid_content:
             return {}
         

--- a/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
@@ -6,7 +6,9 @@ from ..compat import (
     Api, 
     Job, 
     JobStatus,
-    OpenAIFilePurpose
+    OpenAIFilePurpose,
+    ListFilesRequest,
+    RetrieveFileContentRequest,
 )
 from typing import List, Dict, Union
 import os
@@ -329,7 +331,7 @@ class GarakRemoteEvalAdapter(GarakEvalBase):
                             
                             if 'mapping_file_id' not in self._job_metadata[job_id]:
                                 # List files and find the mapping file by name
-                                files_list = await self.file_api.openai_list_files(purpose=OpenAIFilePurpose.BATCH)
+                                files_list = await self.file_api.openai_list_files(ListFilesRequest(purpose=OpenAIFilePurpose.BATCH))
                                 
                                 for file_obj in files_list.data:
                                     if hasattr(file_obj, 'filename') and file_obj.filename == mapping_filename:
@@ -339,7 +341,7 @@ class GarakRemoteEvalAdapter(GarakEvalBase):
                             
                             if mapping_file_id := self._job_metadata[job_id].get('mapping_file_id'):
                                 # Retrieve the mapping file via Files API
-                                mapping_content = await self.file_api.openai_retrieve_file_content(mapping_file_id)
+                                mapping_content = await self.file_api.openai_retrieve_file_content(RetrieveFileContentRequest(file_id=mapping_file_id))
                                 if mapping_content:
                                     file_id_mapping: dict = json.loads(mapping_content.body.decode("utf-8"))
                                     

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
@@ -81,6 +81,7 @@ def validate_inputs(
 
     from llama_stack_client import LlamaStackClient
     from llama_stack_provider_trustyai_garak.utils import get_http_client_with_tls
+    from llama_stack_provider_trustyai_garak.errors import GarakValidationError
     
     validation_errors = []
     
@@ -115,6 +116,9 @@ def validate_inputs(
     for flag in dangerous_flags:
         if flag in command:
             validation_errors.append(f"Dangerous flag detected: {flag}")
+    
+    if len(validation_errors) > 0:
+        raise GarakValidationError("\n".join(validation_errors))
     
     return (
         len(validation_errors) == 0,

--- a/tests/test_remote_provider.py
+++ b/tests/test_remote_provider.py
@@ -11,7 +11,7 @@ from llama_stack_provider_trustyai_garak.remote.garak_remote_eval import GarakRe
 from llama_stack_provider_trustyai_garak.remote.provider import get_provider_spec
 from llama_stack_provider_trustyai_garak.config import GarakRemoteConfig, KubeflowConfig, GarakScanConfig
 from llama_stack_provider_trustyai_garak.errors import GarakConfigError, GarakValidationError
-from llama_stack_provider_trustyai_garak.compat import Api, JobStatus, EvaluateResponse, Benchmark
+from llama_stack_provider_trustyai_garak.compat import Api, JobStatus, EvaluateResponse, Benchmark, RetrieveFileContentRequest
 
 class TestRemoteProvider:
     """Test cases for remote provider specification"""
@@ -616,7 +616,7 @@ class TestGarakRemoteEvalAdapter:
             # Verify we used cached ID and didn't call list_files
             adapter.file_api.openai_list_files.assert_not_called()
             # But we did retrieve content using the cached ID
-            adapter.file_api.openai_retrieve_file_content.assert_called_once_with("cached-mapping-id-456")
+            adapter.file_api.openai_retrieve_file_content.assert_called_once_with(RetrieveFileContentRequest(file_id="cached-mapping-id-456"))
 
     @pytest.mark.asyncio
     async def test_job_result_completed(self, adapter, mock_file_api, mock_benchmark):


### PR DESCRIPTION
## Summary by Sourcery

Update the provider to be compatible with llama-stack 0.4.x client APIs and tighten validation behavior in the remote KFP components.

Bug Fixes:
- Adapt benchmark and files API calls to use the new request object types required by llama-stack 0.4.x.
- Raise a GarakValidationError when dangerous or invalid KFP inputs are detected instead of silently returning errors.

Enhancements:
- Expose additional benchmark and files request types through the compat layer for downstream use.

Build:
- Bump package version to 0.1.8 and depend on llama-stack[client]>=0.4.0.

Tests:
- Update remote provider tests to assert the new file content retrieval call signature.