### PR TITLE
feat: support disconnected mode with pre-downloaded HF model cache

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "kfp-server-api>=2.14.6",
     "boto3>=1.35.88",
     # eval-hub integration
-    "eval-hub-sdk[adapter]>=0.1.4",
+    "eval-hub-sdk[adapter]==0.1.4",
     "pandas>=2.3.3",
     "Jinja2>=3.1.6",
 ]

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -416,11 +416,18 @@ class GarakAdapter(FrameworkAdapter):
             )
         )
 
+        env: dict[str, str] = {}
+        hf_cache = (config.parameters or {}).get("hf_cache_path", "")
+        if hf_cache:
+            env["HF_HUB_CACHE"] = hf_cache
+            logger.info("Using HF cache from mounted path: %s", hf_cache)
+
         result = run_garak_scan(
             config_file=config_file,
             timeout_seconds=timeout,
             log_file=log_file,
             report_prefix=report_prefix,
+            env=env if env else None,
         )
 
         # AVID conversion
@@ -554,6 +561,7 @@ class GarakAdapter(FrameworkAdapter):
             "sdg_max_concurrency": ip.get("sdg_max_concurrency", DEFAULT_SDG_MAX_CONCURRENCY),
             "sdg_num_samples": ip.get("sdg_num_samples", DEFAULT_SDG_NUM_SAMPLES),
             "sdg_max_tokens": ip.get("sdg_max_tokens", DEFAULT_SDG_MAX_TOKENS),
+            "hf_cache_path": benchmark_config.get("hf_cache_path", ""),
         }
         if model_auth_secret:
             pipeline_args["model_auth_secret_name"] = model_auth_secret
@@ -595,7 +603,6 @@ class GarakAdapter(FrameworkAdapter):
                     ),
                 )
             )
-            s3_bucket = kfp_config.s3_bucket or os.getenv("AWS_S3_BUCKET", "")
             creds = (
                 self._read_s3_credentials_from_secret(
                     kfp_config.s3_secret_name,
@@ -616,11 +623,13 @@ class GarakAdapter(FrameworkAdapter):
                     kfp_config.s3_secret_name,
                     kfp_config.namespace,
                 )
+            s3_bucket = kfp_config.s3_bucket or creds.pop("bucket", "") or os.getenv("AWS_S3_BUCKET", "")
+            s3_endpoint = kfp_config.s3_endpoint or creds.pop("endpoint_url", "") or None
             self._download_results_from_s3(
                 s3_bucket,
                 s3_prefix,
                 scan_dir,
-                endpoint_url=kfp_config.s3_endpoint or None,
+                endpoint_url=s3_endpoint,
                 **creds,
             )
 
@@ -770,6 +779,8 @@ class GarakAdapter(FrameworkAdapter):
                 "access_key": _decode("AWS_ACCESS_KEY_ID"),
                 "secret_key": _decode("AWS_SECRET_ACCESS_KEY"),
                 "region": _decode("AWS_DEFAULT_REGION"),
+                "bucket": _decode("AWS_S3_BUCKET"),
+                "endpoint_url": _decode("AWS_S3_ENDPOINT"),
             }
         except Exception as exc:
             logger.warning("Could not read S3 credentials from secret %s/%s: %s", namespace, secret_name, exc)
@@ -1288,6 +1299,22 @@ class GarakAdapter(FrameworkAdapter):
             raw_entries_by_probe=raw_entries_by_probe,
         )
         overall_summary = combined.get("scores", {}).get("_overall", {}).get("aggregated_results", {})
+
+        overall_asr = overall_summary.get("attack_success_rate")
+        if overall_asr is not None:
+            try:
+                overall_asr = float(overall_asr)
+            except (TypeError, ValueError):
+                overall_asr = None
+        if overall_asr is not None:
+            metrics.append(
+                EvaluationResult(
+                    metric_name="attack_success_rate",
+                    metric_value=overall_asr,
+                    metric_type="percentage",
+                    num_samples=overall_summary.get("total_attempts"),
+                )
+            )
 
         # Convert to EvaluationResult format (one per probe)
         for probe_name, score_data in combined["scores"].items():

--- a/src/llama_stack_provider_trustyai_garak/evalhub/kfp_pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/kfp_pipeline.py
@@ -441,6 +441,7 @@ def garak_scan(
     config_json: str,
     s3_prefix: str,
     timeout_seconds: int,
+    hf_cache_path: str,
     prompts_dataset: dsl.Input[dsl.Dataset],
 ) -> NamedTuple("Outputs", [("success", bool), ("return_code", int)]):
     """Run a Garak scan and upload output to S3 via Data Connection credentials.
@@ -468,6 +469,54 @@ def garak_scan(
         redact_api_keys,
     )
     from llama_stack_provider_trustyai_garak.errors import GarakError
+
+    if hf_cache_path and hf_cache_path.strip():
+        from llama_stack_provider_trustyai_garak.evalhub.s3_utils import create_s3_client
+
+        if hf_cache_path.startswith("s3://"):
+            parts = hf_cache_path[len("s3://") :].split("/", 1)
+            bucket = parts[0]
+            prefix = parts[1] if len(parts) > 1 else ""
+        else:
+            bucket = os.environ.get("AWS_S3_BUCKET", "")
+            prefix = hf_cache_path.lstrip("/")
+
+        if not bucket:
+            raise GarakError(
+                "Cannot determine S3 bucket for HF cache. "
+                "Provide a full s3://bucket/prefix URI in hf_cache_path, "
+                "or set AWS_S3_BUCKET."
+            )
+
+        if not prefix:
+            log.warning(
+                "hf_cache_path has no sub-prefix; downloading all objects from bucket '%s'.",
+                bucket,
+            )
+
+        hf_cache_dir = Path(tempfile.mkdtemp(prefix="hf-cache-"))
+        s3 = create_s3_client()
+        downloaded = 0
+
+        paginator = s3.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
+            for obj in page.get("Contents", []):
+                rel = obj["Key"][len(prefix) :].lstrip("/")
+                if not rel:
+                    continue
+                dest = hf_cache_dir / rel
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                s3.download_file(bucket, obj["Key"], str(dest))
+                downloaded += 1
+
+        os.environ["HF_HUB_CACHE"] = str(hf_cache_dir)
+        log.info(
+            "Populated HF cache from s3://%s/%s -> %s (%d files)",
+            bucket,
+            prefix,
+            hf_cache_dir,
+            downloaded,
+        )
 
     scan_dir = Path(tempfile.mkdtemp(prefix="garak-scan-"))
 
@@ -639,6 +688,7 @@ def evalhub_garak_pipeline(
     sdg_max_concurrency: int = DEFAULT_SDG_MAX_CONCURRENCY,
     sdg_num_samples: int = DEFAULT_SDG_NUM_SAMPLES,
     sdg_max_tokens: int = DEFAULT_SDG_MAX_TOKENS,
+    hf_cache_path: str = "",
 ):
     """Six-step pipeline: validate, resolve taxonomy, SDG, prepare prompts, scan, write outputs.
 
@@ -736,6 +786,7 @@ def evalhub_garak_pipeline(
         config_json=config_json,
         s3_prefix=s3_prefix,
         timeout_seconds=timeout_seconds,
+        hf_cache_path=hf_cache_path,
         prompts_dataset=prep_task.outputs["prompts_dataset"],
     )
     scan_task.set_caching_options(False)

--- a/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/garak_remote_eval.py
@@ -211,6 +211,7 @@ class GarakRemoteEvalAdapter(GarakEvalBase):
                         provider_params.get("sdg_max_tokens", DEFAULT_SDG_MAX_TOKENS),
                         DEFAULT_SDG_MAX_TOKENS,
                     ),
+                    "hf_cache_path": provider_params.get("hf_cache_path", ""),
                 },
                 run_name=f"garak-{benchmark_id.split('::')[-1]}-{job_id.removeprefix(JOB_ID_PREFIX)}",
                 namespace=self._config.kubeflow_config.namespace,

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/components.py
@@ -397,6 +397,7 @@ def garak_scan(
     job_id: str,
     timeout_seconds: int,
     verify_ssl: str,
+    hf_cache_path: str,
     prompts_dataset: dsl.Input[dsl.Dataset],
 ) -> NamedTuple(
     "Outputs",
@@ -419,12 +420,18 @@ def garak_scan(
     )
     log = logging.getLogger("garak_scan")
 
+    import os
+
     from llama_stack_client import LlamaStackClient
     from llama_stack_provider_trustyai_garak.utils import get_http_client_with_tls
     from llama_stack_provider_trustyai_garak.core.pipeline_steps import (
         setup_and_run_garak,
         redact_api_keys,
     )
+
+    if hf_cache_path and hf_cache_path.strip():
+        os.environ["HF_HUB_CACHE"] = hf_cache_path
+        log.info("Set HF_HUB_CACHE=%s for disconnected mode", hf_cache_path)
 
     scan_dir = Path(tempfile.mkdtemp(prefix="garak-scan-"))
 

--- a/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/remote/kfp_utils/pipeline.py
@@ -53,6 +53,7 @@ def garak_scan_pipeline(
     sdg_max_concurrency: int = DEFAULT_SDG_MAX_CONCURRENCY,
     sdg_num_samples: int = DEFAULT_SDG_NUM_SAMPLES,
     sdg_max_tokens: int = DEFAULT_SDG_MAX_TOKENS,
+    hf_cache_path: str = "",
 ):
     """Six-step pipeline: validate, resolve taxonomy, SDG, prepare prompts, scan, parse.
 
@@ -120,6 +121,7 @@ def garak_scan_pipeline(
         job_id=job_id,
         timeout_seconds=timeout_seconds,
         verify_ssl=verify_ssl,
+        hf_cache_path=hf_cache_path,
         prompts_dataset=prep_task.outputs["prompts_dataset"],
     )
     scan_task.set_caching_options(False)

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -189,6 +189,88 @@ def test_run_benchmark_job_uses_garak_config_file(monkeypatch, tmp_path):
     assert captured["timeout_seconds"] == 42
 
 
+def test_simple_mode_passes_hf_cache_env(monkeypatch, tmp_path):
+    """When hf_cache_path is set, _run_simple passes HF_HUB_CACHE via env to run_garak_scan."""
+    module = _load_evalhub_garak_adapter(monkeypatch)
+    adapter = module.GarakAdapter()
+    monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_garak_scan(config_file, timeout_seconds, report_prefix, env=None, log_file=None):
+        captured["env"] = env
+        report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+        return module.GarakScanResult(returncode=0, stdout="", stderr="", report_prefix=report_prefix)
+
+    monkeypatch.setattr(module, "run_garak_scan", _fake_run_garak_scan)
+    monkeypatch.setattr(module, "convert_to_avid_report", lambda _path: True)
+    monkeypatch.setattr(
+        module.GarakAdapter,
+        "_parse_results",
+        lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+    )
+
+    class _Callbacks:
+        def report_status(self, _update):
+            return None
+
+        def create_oci_artifact(self, _spec):
+            return SimpleNamespace(reference="oci://ref", digest="sha256:test")
+
+    job = SimpleNamespace(
+        id="hf-cache-job",
+        benchmark_id="trustyai_garak::quick",
+        benchmark_index=0,
+        model=SimpleNamespace(url="http://localhost:8000", name="test-model"),
+        parameters={"hf_cache_path": "/test_data/hf-cache"},
+        exports=None,
+    )
+
+    adapter.run_benchmark_job(job, _Callbacks())
+    assert captured["env"] == {"HF_HUB_CACHE": "/test_data/hf-cache"}
+
+
+def test_simple_mode_no_hf_cache_passes_none_env(monkeypatch, tmp_path):
+    """When hf_cache_path is not set, env=None is passed (default behavior)."""
+    module = _load_evalhub_garak_adapter(monkeypatch)
+    adapter = module.GarakAdapter()
+    monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
+    captured: dict[str, object] = {}
+
+    def _fake_run_garak_scan(config_file, timeout_seconds, report_prefix, env=None, log_file=None):
+        captured["env"] = env
+        report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+        return module.GarakScanResult(returncode=0, stdout="", stderr="", report_prefix=report_prefix)
+
+    monkeypatch.setattr(module, "run_garak_scan", _fake_run_garak_scan)
+    monkeypatch.setattr(module, "convert_to_avid_report", lambda _path: True)
+    monkeypatch.setattr(
+        module.GarakAdapter,
+        "_parse_results",
+        lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+    )
+
+    class _Callbacks:
+        def report_status(self, _update):
+            return None
+
+        def create_oci_artifact(self, _spec):
+            return SimpleNamespace(reference="oci://ref", digest="sha256:test")
+
+    job = SimpleNamespace(
+        id="no-hf-cache-job",
+        benchmark_id="trustyai_garak::quick",
+        benchmark_index=0,
+        model=SimpleNamespace(url="http://localhost:8000", name="test-model"),
+        parameters={},
+        exports=None,
+    )
+
+    adapter.run_benchmark_job(job, _Callbacks())
+    assert captured["env"] is None
+
+
 def test_parse_results_uses_overall_without_double_count(monkeypatch, tmp_path):
     module = _load_evalhub_garak_adapter(monkeypatch)
     adapter = module.GarakAdapter()
@@ -245,8 +327,11 @@ def test_parse_results_uses_overall_without_double_count(monkeypatch, tmp_path):
     )
     metrics, overall_score, num_examples, overall_summary = adapter._parse_results(result, 0.5)
 
-    assert len(metrics) == 1
-    assert metrics[0].metric_name == "probe.alpha_asr"
+    assert len(metrics) == 2
+    assert metrics[0].metric_name == "attack_success_rate"
+    assert metrics[0].metric_value == 30.0
+    assert metrics[0].num_samples == 10
+    assert metrics[1].metric_name == "probe.alpha_asr"
     assert overall_score == 30.0
     assert num_examples == 10
     assert overall_summary["tbsa"] == 4.1
@@ -1882,15 +1967,18 @@ class TestParseResultsIntentsMode:
             art_intents=True,
         )
 
-        assert len(metrics) == 1
-        assert metrics[0].metric_name == "spo.SPOIntent_asr"
+        assert len(metrics) == 2
+        assert metrics[0].metric_name == "attack_success_rate"
         assert metrics[0].metric_value == 30.0
-        assert metrics[0].num_samples is None
-        assert metrics[0].metadata["total_attempts"] == 20
-        assert metrics[0].metadata["unsafe_stubs"] == 3
-        assert metrics[0].metadata["safe_stubs"] == 7
-        assert "intent_breakdown" in metrics[0].metadata
-        assert metrics[0].metadata["intent_breakdown"]["S001"]["unsafe_stubs"] == 2
+        assert metrics[0].num_samples == 20
+        assert metrics[1].metric_name == "spo.SPOIntent_asr"
+        assert metrics[1].metric_value == 30.0
+        assert metrics[1].num_samples is None
+        assert metrics[1].metadata["total_attempts"] == 20
+        assert metrics[1].metadata["unsafe_stubs"] == 3
+        assert metrics[1].metadata["safe_stubs"] == 7
+        assert "intent_breakdown" in metrics[1].metadata
+        assert metrics[1].metadata["intent_breakdown"]["S001"]["unsafe_stubs"] == 2
         assert overall_score == 30.0
         assert num_examples == 20
 


### PR DESCRIPTION
## Summary
- Adds `hf_cache_path` parameter across all execution modes (EvalHub simple, EvalHub KFP, Llama Stack remote KFP) to support air-gapped/disconnected clusters where `multilingual.TranslationIntent` probes need Helsinki-NLP translation models pre-downloaded from HuggingFace.
- **Evalhub-KFP mode**: `hf_cache_path` accepts an S3 prefix or fully-qualified `s3://bucket/prefix` URI. The `garak_scan` component downloads the HF cache from S3 into a temp directory and sets `HF_HUB_CACHE` before running.
- include bucket & endpoint from K8s secret when available
- emit overall `attack_success_rate` (uses same computation as html report) as first metric in job results
- Pins `eval-hub-sdk[adapter]` to `==0.1.4`.

## Test plan
- [x] Unit tests for simple mode HF cache env propagation (`test_simple_mode_passes_hf_cache_env`)
- [x] Unit tests for simple mode without HF cache (`test_simple_mode_no_hf_cache_passes_none_env`)
- [x] Manual testing with `HF_HUB_OFFLINE=1` in Containerfile — without `hf_cache_path` scan fails to connect to HF; with `hf_cache_path` scan succeeds using cached models from S3
      - Pre-download :

```
huggingface-cli download Helsinki-NLP/opus-mt-zh-en --cache-dir /tmp/hf-test-cache
huggingface-cli download Helsinki-NLP/opus-mt-en-zh --cache-dir /tmp/hf-test-cache
```

   - Upload to S3:

```
aws s3 sync /tmp/hf-test-cache s3://your-bucket/models/ --exclude ".locks/*"
```

   - without `hf_cache_path` (shouldn't load model from internet):

```
[KFP Executor 2026-04-08 22:06:48,349 INFO]: Generated intent stubs for 8 prompts across 8 categories
[KFP Executor 2026-04-08 22:06:48,349 INFO]: Starting garak scan (timeout=0s, output=/tmp/garak-scan-crgr6a2s)
[KFP Executor 2026-04-08 22:06:48,443 INFO]: garak[stdout] garak LLM vulnerability scanner v0.14.1+rhaiv.7 ( https://github.com/NVIDIA/garak ) at 2026-04-08T22:06:48.431774
[KFP Executor 2026-04-08 22:06:48,781 INFO]: garak[stdout] ⚠️  A possibly secret value (`api_key`) was detected in /tmp/garak-scan-crgr6a2s/config.json, which is readable by users other than yourself. Consider changing permissions on this file to only be readable by you.
[KFP Executor 2026-04-08 22:06:48,788 INFO]: garak[stdout] 📜 logging to /tmp/garak-scan-crgr6a2s/scan.log
[KFP Executor 2026-04-08 22:06:51,392 INFO]: garak[stdout] 🦜 loading generator: OpenAICompatible: ilyagusevgemma-2-9b-it-abliterated
[KFP Executor 2026-04-08 22:06:51,393 INFO]: garak[stdout] 📜 reporting to /tmp/garak-scan-crgr6a2s/scan.report.jsonl
[KFP Executor 2026-04-08 22:06:51,401 INFO]: garak[stdout] 🌐 loading language services: zh,en->local.LocalHFTranslator[Helsinki-NLP/opus-mt-zh-en] en,zh->local.LocalHFTranslator[Helsinki-NLP/opus-mt-en-zh]
[KFP Executor 2026-04-08 22:06:55,114 INFO]: garak[stdout] We couldn't connect to 'https://huggingface.co' to load the files, and couldn't find them in the cached files.
[KFP Executor 2026-04-08 22:06:55,114 INFO]: garak[stdout] Check your internet connection or see how to run the library in offline mode at 'https://huggingface.co/docs/transformers/installation#offline-mode'.
[KFP Executor 2026-04-08 22:06:56,042 INFO]: Garak scan completed successfully
.
.
.
```

   - with `hf_cache_path=s3://your-bucket/models/` (should download from s3 and use local cache):
   
```
[KFP Executor 2026-04-08 22:08:32,695 INFO]: Populated HF cache from s3://hf-models/models/ -> /tmp/hf-cache-724_gzmn (52 files)
[KFP Executor 2026-04-08 22:08:32,715 INFO]: Generated intent stubs for 8 prompts across 8 categories
[KFP Executor 2026-04-08 22:08:32,715 INFO]: Starting garak scan (timeout=0s, output=/tmp/garak-scan-wpb3v8ma)
[KFP Executor 2026-04-08 22:08:32,808 INFO]: garak[stdout] garak LLM vulnerability scanner v0.14.1+rhaiv.7 ( https://github.com/NVIDIA/garak ) at 2026-04-08T22:08:32.797396
[KFP Executor 2026-04-08 22:08:33,120 INFO]: garak[stdout] ⚠️  A possibly secret value (`api_key`) was detected in /tmp/garak-scan-wpb3v8ma/config.json, which is readable by users other than yourself. Consider changing permissions on this file to only be readable by you.
[KFP Executor 2026-04-08 22:08:33,127 INFO]: garak[stdout] 📜 logging to /tmp/garak-scan-wpb3v8ma/scan.log
[KFP Executor 2026-04-08 22:08:35,754 INFO]: garak[stdout] 🦜 loading generator: OpenAICompatible: ilyagusevgemma-2-9b-it-abliterated
[KFP Executor 2026-04-08 22:08:35,755 INFO]: garak[stdout] 📜 reporting to /tmp/garak-scan-wpb3v8ma/scan.report.jsonl
[KFP Executor 2026-04-08 22:08:35,763 INFO]: garak[stdout] 🌐 loading language services: zh,en->local.LocalHFTranslator[Helsinki-NLP/opus-mt-zh-en] en,zh->local.LocalHFTranslator[Helsinki-NLP/opus-mt-en-zh]
[KFP Executor 2026-04-08 22:08:39,882 INFO]: garak[progress] Loading weights:   0%|          | 0/258 [00:00<?, ?it/s]
[KFP Executor 2026-04-08 22:08:39,882 INFO]: garak[progress] Loading weights: 100%|██████████| 258/258 [00:00<00:00, 30504.89it/s]
[KFP Executor 2026-04-08 22:08:41,101 INFO]: garak[progress] /opt/app-root/lib64/python3.12/site-packages/transformers/models/marian/tokenization_marian.py:176: UserWarning: Recommended: pip install sacremoses.
[KFP Executor 2026-04-08 22:08:41,101 WARNING]: garak[stderr]   warnings.warn("Recommended: pip install sacremoses.")
[KFP Executor 2026-04-08 22:08:41,547 INFO]: garak[progress] Loading weights:   0%|          | 0/258 [00:00<?, ?it/s]
[KFP Executor 2026-04-08 22:08:41,547 INFO]: garak[progress] Loading weights: 100%|██████████| 258/258 [00:00<00:00, 19101.03it/s]
[KFP Executor 2026-04-08 22:08:42,771 INFO]: garak[stdout] 🎯 loading intent service
[KFP Executor 2026-04-08 22:08:42,771 INFO]: garak[stdout] 🎯 intents active: S001fraud, S002hatespeech, S003illegalactivity, S004misinformation, S005securitymalware, S006selfharm, S007sexuallyexplicit, S008violence
[KFP Executor 2026-04-08 22:08:42,781 INFO]: garak[stdout] 🦜 loading generator: OpenAICompatible: ilyagusevgemma-2-9b-it-abliterated
[KFP Executor 2026-04-08 22:08:42,808 INFO]: garak[progress] Preparing prompts:   0%|          | 0/8 [00:00<?, ?it/s]
[KFP Executor 2026-04-08 22:08:42,809 INFO]: garak[progress]   0%|          | 0/8 [00:00<?, ?it/s]
[KFP Executor 2026-04-08 22:08:44
.
.
.
```

## Summary by Sourcery

Add support for specifying a Hugging Face model cache path to enable disconnected/offline evaluation across simple EvalHub runs and KFP-based pipelines, and pin the eval-hub SDK dependency version.

New Features:
- Allow simple EvalHub execution mode to read an optional hf_cache_path parameter and forward it as the HF_HUB_CACHE environment variable to Garak scans.
- Extend EvalHub KFP and remote KFP pipelines to accept an hf_cache_path parameter and propagate it into the Garak scan components for offline model loading.
- Download a pre-populated Hugging Face cache from S3 into a temporary directory in the EvalHub KFP scan component when hf_cache_path points to an S3 location.

Enhancements:
- Log configuration when using a mounted or S3-backed Hugging Face cache for Garak scans.

Build:
- Pin eval-hub-sdk[adapter] to version 0.1.4 to ensure compatibility with the new behavior.

Tests:
- Add unit tests to verify HF_HUB_CACHE is correctly set or omitted in simple mode based on the presence of hf_cache_path.