### PR TITLE
fix: normalize evalhub metrics to 0-1 ratio scale for UI compatibility

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1310,8 +1310,8 @@ class GarakAdapter(FrameworkAdapter):
             metrics.append(
                 EvaluationResult(
                     metric_name="attack_success_rate",
-                    metric_value=overall_asr,
-                    metric_type="percentage",
+                    metric_value=round(overall_asr / 100, 4),
+                    metric_type="ratio",
                     num_samples=overall_summary.get("total_attempts"),
                 )
             )
@@ -1350,8 +1350,8 @@ class GarakAdapter(FrameworkAdapter):
             metrics.append(
                 EvaluationResult(
                     metric_name=f"{probe_name}_asr",
-                    metric_value=attack_success_rate,
-                    metric_type="percentage",
+                    metric_value=round(attack_success_rate / 100, 4),
+                    metric_type="ratio",
                     num_samples=probe_attempts if not art_intents else None,
                     metadata=probe_metadata,
                 )
@@ -1360,7 +1360,7 @@ class GarakAdapter(FrameworkAdapter):
         overall_score = overall_summary.get("attack_success_rate")
         if overall_score is not None:
             try:
-                overall_score = float(overall_score)
+                overall_score = round(float(overall_score) / 100, 4)
             except (TypeError, ValueError):
                 overall_score = None
 
@@ -1370,7 +1370,7 @@ class GarakAdapter(FrameworkAdapter):
                 for probe_name, score_data in combined["scores"].items()
                 if probe_name != "_overall"
             )
-            overall_score = round((total_vulnerable / total_attempts) * 100, 2)
+            overall_score = round(total_vulnerable / total_attempts, 4)
 
         num_examples = overall_summary.get("total_attempts", total_attempts)
         try:
@@ -1531,7 +1531,7 @@ def main(adapter_cls: type[GarakAdapter] = GarakAdapter) -> None:
 
         results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
         logger.info(f"Job completed successfully: {results.id}")
-        logger.info(f"Overall attack success rate: {results.overall_score}%")
+        logger.info(f"Overall attack success rate: {results.overall_score}")
 
         callbacks.report_results(results)
         sys.exit(0)

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1250,6 +1250,11 @@ class GarakAdapter(FrameworkAdapter):
 
     #     return env
 
+    @staticmethod
+    def _pct_to_ratio(value: float) -> float:
+        """Convert a 0-100 percentage to a 0-1 ratio."""
+        return round(value / 100, 4)
+
     def _parse_results(
         self,
         result: GarakScanResult,
@@ -1310,7 +1315,7 @@ class GarakAdapter(FrameworkAdapter):
             metrics.append(
                 EvaluationResult(
                     metric_name="attack_success_rate",
-                    metric_value=round(overall_asr / 100, 4),
+                    metric_value=self._pct_to_ratio(overall_asr),
                     metric_type="ratio",
                     num_samples=overall_summary.get("total_attempts"),
                 )
@@ -1350,7 +1355,7 @@ class GarakAdapter(FrameworkAdapter):
             metrics.append(
                 EvaluationResult(
                     metric_name=f"{probe_name}_asr",
-                    metric_value=round(attack_success_rate / 100, 4),
+                    metric_value=self._pct_to_ratio(attack_success_rate),
                     metric_type="ratio",
                     num_samples=probe_attempts if not art_intents else None,
                     metadata=probe_metadata,
@@ -1360,7 +1365,7 @@ class GarakAdapter(FrameworkAdapter):
         overall_score = overall_summary.get("attack_success_rate")
         if overall_score is not None:
             try:
-                overall_score = round(float(overall_score) / 100, 4)
+                overall_score = self._pct_to_ratio(float(overall_score))
             except (TypeError, ValueError):
                 overall_score = None
 
@@ -1370,7 +1375,7 @@ class GarakAdapter(FrameworkAdapter):
                 for probe_name, score_data in combined["scores"].items()
                 if probe_name != "_overall"
             )
-            overall_score = round(total_vulnerable / total_attempts, 4)
+            overall_score = self._pct_to_ratio((total_vulnerable / total_attempts) * 100)
 
         num_examples = overall_summary.get("total_attempts", total_attempts)
         try:
@@ -1531,7 +1536,7 @@ def main(adapter_cls: type[GarakAdapter] = GarakAdapter) -> None:
 
         results = adapter.run_benchmark_job(adapter.job_spec, callbacks)
         logger.info(f"Job completed successfully: {results.id}")
-        logger.info(f"Overall attack success rate: {results.overall_score}")
+        logger.info(f"Overall attack success rate (ratio): {results.overall_score}")
 
         callbacks.report_results(results)
         sys.exit(0)

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -329,9 +329,11 @@ def test_parse_results_uses_overall_without_double_count(monkeypatch, tmp_path):
 
     assert len(metrics) == 2
     assert metrics[0].metric_name == "attack_success_rate"
+    assert metrics[0].metric_type == "ratio"
     assert metrics[0].metric_value == 0.3
     assert metrics[0].num_samples == 10
     assert metrics[1].metric_name == "probe.alpha_asr"
+    assert metrics[1].metric_type == "ratio"
     assert overall_score == 0.3
     assert num_examples == 10
     assert overall_summary["tbsa"] == 4.1
@@ -1969,9 +1971,11 @@ class TestParseResultsIntentsMode:
 
         assert len(metrics) == 2
         assert metrics[0].metric_name == "attack_success_rate"
+        assert metrics[0].metric_type == "ratio"
         assert metrics[0].metric_value == 0.3
         assert metrics[0].num_samples == 20
         assert metrics[1].metric_name == "spo.SPOIntent_asr"
+        assert metrics[1].metric_type == "ratio"
         assert metrics[1].metric_value == 0.3
         assert metrics[1].num_samples is None
         assert metrics[1].metadata["total_attempts"] == 20

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -329,10 +329,10 @@ def test_parse_results_uses_overall_without_double_count(monkeypatch, tmp_path):
 
     assert len(metrics) == 2
     assert metrics[0].metric_name == "attack_success_rate"
-    assert metrics[0].metric_value == 30.0
+    assert metrics[0].metric_value == 0.3
     assert metrics[0].num_samples == 10
     assert metrics[1].metric_name == "probe.alpha_asr"
-    assert overall_score == 30.0
+    assert overall_score == 0.3
     assert num_examples == 10
     assert overall_summary["tbsa"] == 4.1
 
@@ -1969,17 +1969,17 @@ class TestParseResultsIntentsMode:
 
         assert len(metrics) == 2
         assert metrics[0].metric_name == "attack_success_rate"
-        assert metrics[0].metric_value == 30.0
+        assert metrics[0].metric_value == 0.3
         assert metrics[0].num_samples == 20
         assert metrics[1].metric_name == "spo.SPOIntent_asr"
-        assert metrics[1].metric_value == 30.0
+        assert metrics[1].metric_value == 0.3
         assert metrics[1].num_samples is None
         assert metrics[1].metadata["total_attempts"] == 20
         assert metrics[1].metadata["unsafe_stubs"] == 3
         assert metrics[1].metadata["safe_stubs"] == 7
         assert "intent_breakdown" in metrics[1].metadata
         assert metrics[1].metadata["intent_breakdown"]["S001"]["unsafe_stubs"] == 2
-        assert overall_score == 30.0
+        assert overall_score == 0.3
         assert num_examples == 20
 
 


### PR DESCRIPTION
## Summary

The evalhub UI expects metric values in the 0-1 range, but the adapter was sending them as percentages (0-100). This caused metrics to render incorrectly in the dashboard.

## Changes

- Normalize `metric_value` from 0-100 to 0-1 in `_parse_results` for both overall ASR and per-probe ASR metrics
- Change `metric_type` from `"percentage"` to `"ratio"` to accurately reflect the scale
- Normalize `overall_score` (from summary and fallback calculation) to 0-1
- Remove misleading `%` suffix from the log message in `main()`
- Update test assertions to match the new 0-1 values

The normalization is scoped to the evalhub adapter boundary — `result_utils.py` still produces 0-100 values used by HTML reports and other consumers.

## Testing Checklist

- [x] Unit tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] New/changed code has test coverage
- [x] No breaking changes to existing benchmark configs
- [ ] Documentation updated (if applicable)

## Summary by Sourcery

Normalize evalhub adapter attack success rate metrics to use 0–1 ratio values instead of 0–100 percentages for UI compatibility.

Bug Fixes:
- Normalize overall and per-probe attack success rate metrics from percentage to ratio scale for evalhub UI consumption.

Enhancements:
- Update overall score computation and logging to use ratio values consistently across the evalhub adapter.

Tests:
- Adjust evalhub adapter tests to assert ratio-scale metric values and scores instead of percentages.