### PR TITLE
feat: enable intents benchmark in non-KFP execution mode

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -129,14 +129,6 @@ class GarakAdapter(FrameworkAdapter):
             execution_mode = self._resolve_execution_mode(benchmark_config)
             logger.info("Execution mode: %s", execution_mode)
 
-            # Early check: intents benchmarks require KFP mode
-            _intents_required = benchmark_config.get("art_intents")
-            if _intents_required is None:
-                _profile = self._resolve_profile(config.benchmark_id)
-                _intents_required = _profile.get("art_intents", False) if _profile else False
-            if _intents_required and execution_mode != EXECUTION_MODE_KFP:
-                raise ValueError("Intents benchmarks are only supported in KFP execution mode. ")
-
             # Build merged garak config (common to both modes)
             scan_dir = get_scan_base_dir() / config.id
             scan_dir.mkdir(parents=True, exist_ok=True)
@@ -166,6 +158,15 @@ class GarakAdapter(FrameworkAdapter):
                     timeout=timeout,
                     intents_params=intents_params,
                     eval_threshold=eval_threshold,
+                )
+            elif art_intents:
+                result = self._run_simple_intents(
+                    config=config,
+                    callbacks=callbacks,
+                    garak_config_dict=garak_config_dict,
+                    scan_dir=scan_dir,
+                    timeout=timeout,
+                    intents_params=intents_params,
                 )
             else:
                 result = self._run_simple(
@@ -445,6 +446,180 @@ class GarakAdapter(FrameworkAdapter):
                 )
             )
             convert_to_avid_report(result.report_jsonl)
+
+        return result
+
+    # ------------------------------------------------------------------
+    # Simple intents (subprocess with SDG preprocessing)
+    # ------------------------------------------------------------------
+
+    def _run_simple_intents(
+        self,
+        config: JobSpec,
+        callbacks: JobCallbacks,
+        garak_config_dict: dict,
+        scan_dir: Path,
+        timeout: int,
+        intents_params: dict[str, Any],
+    ) -> GarakScanResult:
+        """Run an intents benchmark as a local subprocess with in-process SDG.
+
+        Executes the intents pipeline steps sequentially:
+        1. Resolve taxonomy (local file or default BASE_TAXONOMY)
+        2. Run SDG generation (or bypass if intents_s3_key provided)
+        3. Normalize prompts
+        4. Delegate to setup_and_run_garak() for stub generation + scan
+
+        External files (taxonomy, bypass prompts) are expected as local
+        paths pre-downloaded by the EvalHub SDK to ``/test_data``.  The
+        existing ``policy_s3_key`` / ``intents_s3_key`` parameters are
+        reused as local file paths in simple mode.
+        """
+        from ..core.pipeline_steps import (
+            normalize_prompts,
+            resolve_taxonomy_data,
+            run_sdg_generation,
+            setup_and_run_garak,
+        )
+
+        policy_path = intents_params.get("policy_s3_key", "")
+        policy_format = intents_params.get("policy_format", "csv")
+        intents_path = intents_params.get("intents_s3_key", "")
+        intents_format = intents_params.get("intents_format", "csv")
+
+        # -- Step 1: Resolve taxonomy --------------------------------
+        callbacks.report_status(
+            JobStatusUpdate(
+                status=JobStatus.RUNNING,
+                phase=JobPhase.RUNNING_EVALUATION,
+                progress=0.05,
+                message=MessageInfo(
+                    message="Resolving taxonomy for intents scan",
+                    message_code="resolving_taxonomy",
+                ),
+                current_step="Resolving taxonomy",
+            )
+        )
+
+        policy_content: bytes | None = None
+        if policy_path and policy_path.strip():
+            policy_file = Path(policy_path)
+            if not policy_file.exists():
+                raise FileNotFoundError(
+                    f"Taxonomy file not found at '{policy_path}'. Ensure the file is available via test_data_ref."
+                )
+            policy_content = policy_file.read_bytes()
+            logger.info("Read taxonomy from local path: %s (%d bytes)", policy_path, len(policy_content))
+
+        taxonomy_df = resolve_taxonomy_data(policy_content, format=policy_format)
+        logger.info("Resolved taxonomy: %d entries", len(taxonomy_df))
+
+        # -- Step 2: Generate prompts (SDG or bypass) ----------------
+        raw_content: str | None = None
+
+        if intents_path and intents_path.strip():
+            callbacks.report_status(
+                JobStatusUpdate(
+                    status=JobStatus.RUNNING,
+                    phase=JobPhase.RUNNING_EVALUATION,
+                    progress=0.1,
+                    message=MessageInfo(
+                        message="Loading pre-generated prompts (bypass SDG)",
+                        message_code="bypass_sdg",
+                    ),
+                    current_step="Loading bypass prompts",
+                )
+            )
+            intents_file = Path(intents_path)
+            if not intents_file.exists():
+                raise FileNotFoundError(
+                    f"Intents file not found at '{intents_path}'. Ensure the file is available via test_data_ref."
+                )
+            raw_content = intents_file.read_text(encoding="utf-8")
+            logger.info("Read bypass prompts from local path: %s (%d bytes)", intents_path, len(raw_content))
+        else:
+            callbacks.report_status(
+                JobStatusUpdate(
+                    status=JobStatus.RUNNING,
+                    phase=JobPhase.RUNNING_EVALUATION,
+                    progress=0.1,
+                    message=MessageInfo(
+                        message="Running Synthetic Data Generation",
+                        message_code="running_sdg",
+                    ),
+                    current_step="Generating adversarial prompts via SDG",
+                )
+            )
+            sdg_model = intents_params.get("sdg_model", "")
+            sdg_api_base = intents_params.get("sdg_api_base", "")
+            if not sdg_model or not sdg_api_base:
+                raise ValueError(
+                    "Intents benchmark requires sdg_model and sdg_api_base "
+                    "for prompt generation when intents_s3_key is not provided."
+                )
+
+            raw_df = run_sdg_generation(
+                taxonomy_df=taxonomy_df,
+                sdg_model=sdg_model,
+                sdg_api_base=sdg_api_base,
+                sdg_flow_id=intents_params.get("sdg_flow_id", DEFAULT_SDG_FLOW_ID),
+                sdg_max_concurrency=intents_params.get("sdg_max_concurrency", DEFAULT_SDG_MAX_CONCURRENCY),
+                sdg_num_samples=intents_params.get("sdg_num_samples", DEFAULT_SDG_NUM_SAMPLES),
+                sdg_max_tokens=intents_params.get("sdg_max_tokens", DEFAULT_SDG_MAX_TOKENS),
+            )
+            raw_content = raw_df.to_csv(index=False)
+            logger.info("SDG produced %d rows", len(raw_df))
+
+        # -- Persist raw SDG output ----------------------------------
+        raw_output_path = scan_dir / "sdg_raw_output.csv"
+        raw_output_path.write_text(raw_content, encoding="utf-8")
+        logger.info("Saved raw SDG output to %s", raw_output_path)
+
+        # -- Step 3: Normalize prompts -------------------------------
+        callbacks.report_status(
+            JobStatusUpdate(
+                status=JobStatus.RUNNING,
+                phase=JobPhase.RUNNING_EVALUATION,
+                progress=0.3,
+                message=MessageInfo(
+                    message="Normalizing prompts",
+                    message_code="normalizing_prompts",
+                ),
+                current_step="Normalizing prompts",
+            )
+        )
+
+        fmt = intents_format if (intents_path and intents_path.strip()) else "csv"
+        normalized_df = normalize_prompts(raw_content, format=fmt)
+
+        norm_output_path = scan_dir / "sdg_normalized_output.csv"
+        normalized_df.to_csv(norm_output_path, index=False)
+        logger.info("Saved normalized prompts to %s (%d rows)", norm_output_path, len(normalized_df))
+
+        prompts_csv_path = scan_dir / "prompts.csv"
+        normalized_df.to_csv(prompts_csv_path, index=False)
+
+        # -- Step 4: Run garak scan ----------------------------------
+        callbacks.report_status(
+            JobStatusUpdate(
+                status=JobStatus.RUNNING,
+                phase=JobPhase.RUNNING_EVALUATION,
+                progress=0.4,
+                message=MessageInfo(
+                    message=f"Running Garak intents scan for {config.benchmark_id}",
+                    message_code="running_scan",
+                ),
+                current_step="Executing intents probes",
+            )
+        )
+
+        config_json = json.dumps(garak_config_dict)
+        result = setup_and_run_garak(
+            config_json=config_json,
+            prompts_csv_path=prompts_csv_path,
+            scan_dir=scan_dir,
+            timeout_seconds=timeout,
+        )
 
         return result
 

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -589,6 +589,12 @@ class GarakAdapter(FrameworkAdapter):
             )
         )
 
+        if not (intents_path and intents_path.strip()) and intents_format.strip().lower() != "csv":
+            logger.warning(
+                "intents_format=%r ignored — SDG output is always CSV. "
+                "intents_format only applies when intents_s3_key provides a bypass file.",
+                intents_format,
+            )
         fmt = intents_format if (intents_path and intents_path.strip()) else "csv"
         normalized_df = normalize_prompts(raw_content, format=fmt)
 

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -2074,6 +2074,8 @@ class TestSimpleIntentsMode:
         def _fake_run_sdg_generation(taxonomy_df, sdg_model, sdg_api_base, **kwargs):
             sdg_captured["taxonomy_len"] = len(taxonomy_df)
             sdg_captured["sdg_model"] = sdg_model
+            sdg_captured["sdg_api_base"] = sdg_api_base
+            sdg_captured.update(kwargs)
             return fake_raw_df
 
         def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
@@ -2110,6 +2112,11 @@ class TestSimpleIntentsMode:
 
         assert sdg_captured["taxonomy_len"] == 8  # BASE_TAXONOMY has 8 entries
         assert sdg_captured["sdg_model"] == "sdg-model"
+        assert sdg_captured["sdg_api_base"] == "http://sdg:7000/v1"
+        assert sdg_captured["sdg_flow_id"] == "major-sage-742"
+        assert sdg_captured["sdg_max_concurrency"] == 10
+        assert sdg_captured["sdg_num_samples"] == 0
+        assert sdg_captured["sdg_max_tokens"] == 0
         assert (scan_dir / "sdg_raw_output.csv").exists()
         assert (scan_dir / "sdg_normalized_output.csv").exists()
         assert sdg_captured.get("prompts_csv_path") is not None
@@ -2234,7 +2241,7 @@ class TestSimpleIntentsMode:
             def report_status(self, _update):
                 return None
 
-        with pytest.raises(Exception, match="Taxonomy file not found"):
+        with pytest.raises(FileNotFoundError, match="Taxonomy file not found"):
             adapter.run_benchmark_job(job, _Callbacks())
 
     def test_simple_intents_missing_intents_file_raises(self, monkeypatch, tmp_path):
@@ -2246,7 +2253,7 @@ class TestSimpleIntentsMode:
             def report_status(self, _update):
                 return None
 
-        with pytest.raises(Exception, match="Intents file not found"):
+        with pytest.raises(FileNotFoundError, match="Intents file not found"):
             adapter.run_benchmark_job(job, _Callbacks())
 
     def test_simple_intents_missing_sdg_model_raises(self, monkeypatch, tmp_path):
@@ -2275,7 +2282,7 @@ class TestSimpleIntentsMode:
             def report_status(self, _update):
                 return None
 
-        with pytest.raises(Exception, match="sdg_model.*sdg_api_base"):
+        with pytest.raises(ValueError, match="sdg_model.*sdg_api_base"):
             adapter.run_benchmark_job(job, _Callbacks())
 
     def test_simple_intents_persists_artifacts_to_scan_dir(self, monkeypatch, tmp_path):

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -1996,35 +1996,340 @@ class TestResolveIntentsApiKey:
         assert result == "direct-wins"
 
 
-class TestIntentsRequiresKFP:
-    """Intents benchmarks must reject non-KFP execution modes."""
+class TestSimpleIntentsMode:
+    """Tests for intents benchmark running in simple (non-KFP) mode."""
 
-    def test_intents_simple_mode_raises(self, monkeypatch, tmp_path):
+    def _make_adapter_and_job(self, monkeypatch, tmp_path, parameters=None):
         module = _load_evalhub_garak_adapter(monkeypatch)
         adapter = module.GarakAdapter()
         monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
+        job = SimpleNamespace(
+            id="simple-intents-job",
+            benchmark_id="trustyai_garak::intents",
+            benchmark_index=0,
+            model=SimpleNamespace(url="http://target:8000", name="target-llm"),
+            parameters={
+                "execution_mode": "simple",
+                **_INTENTS_MODELS_ALL_ROLES,
+                **(parameters or {}),
+            },
+            exports=None,
+        )
+        return module, adapter, job
+
+    def test_simple_intents_dispatches_to_run_simple_intents(self, monkeypatch, tmp_path):
+        """Verify art_intents + simple mode routes to _run_simple_intents."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        captured = {}
+        report_prefix = tmp_path / "simple-intents-job" / "scan"
+        report_prefix.parent.mkdir(parents=True, exist_ok=True)
+        report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+
+        def _fake_run_simple_intents(self, config, callbacks, garak_config_dict, scan_dir, timeout, intents_params):
+            captured["called"] = True
+            captured["intents_params"] = intents_params
+            return module.GarakScanResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                report_prefix=report_prefix,
+            )
+
+        monkeypatch.setattr(module.GarakAdapter, "_run_simple_intents", _fake_run_simple_intents)
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
 
         class _Callbacks:
             def report_status(self, _update):
                 return None
 
+        adapter.run_benchmark_job(job, _Callbacks())
+        assert captured.get("called") is True
+        assert captured["intents_params"]["art_intents"] is True
+
+    def test_simple_intents_default_taxonomy_and_sdg(self, monkeypatch, tmp_path):
+        """Full pipeline: default taxonomy -> SDG -> normalize -> scan."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        scan_dir = tmp_path / "simple-intents-job"
+        scan_dir.mkdir(parents=True, exist_ok=True)
+
+        import pandas as pd
+
+        fake_raw_df = pd.DataFrame(
+            {
+                "policy_concept": ["Fraud", "Fraud"],
+                "concept_definition": ["Fraud prompts", "Fraud prompts"],
+                "prompt": ["Commit fraud?", "How to scam?"],
+            }
+        )
+
+        sdg_captured = {}
+
+        def _fake_run_sdg_generation(taxonomy_df, sdg_model, sdg_api_base, **kwargs):
+            sdg_captured["taxonomy_len"] = len(taxonomy_df)
+            sdg_captured["sdg_model"] = sdg_model
+            return fake_raw_df
+
+        def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
+            sdg_captured["prompts_csv_path"] = str(prompts_csv_path)
+            sdg_captured["config_json"] = config_json
+            report_prefix = scan_dir / "scan"
+            report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+            return module.GarakScanResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                report_prefix=report_prefix,
+            )
+
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.run_sdg_generation",
+            _fake_run_sdg_generation,
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.setup_and_run_garak",
+            _fake_setup_and_run,
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        adapter.run_benchmark_job(job, _Callbacks())
+
+        assert sdg_captured["taxonomy_len"] == 8  # BASE_TAXONOMY has 8 entries
+        assert sdg_captured["sdg_model"] == "sdg-model"
+        assert (scan_dir / "sdg_raw_output.csv").exists()
+        assert (scan_dir / "sdg_normalized_output.csv").exists()
+        assert sdg_captured.get("prompts_csv_path") is not None
+
+    def test_simple_intents_custom_taxonomy_from_local_path(self, monkeypatch, tmp_path):
+        """Custom taxonomy loaded from a local file path (pre-downloaded by SDK)."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        taxonomy_file = tmp_path / "test_data" / "taxonomy.csv"
+        taxonomy_file.parent.mkdir(parents=True, exist_ok=True)
+        taxonomy_file.write_text(
+            "policy_concept,concept_definition\nCustomHarm,Custom harm definition\n",
+            encoding="utf-8",
+        )
+        job.parameters["policy_s3_key"] = str(taxonomy_file)
+
+        scan_dir = tmp_path / "simple-intents-job"
+        scan_dir.mkdir(parents=True, exist_ok=True)
+
+        import pandas as pd
+
+        sdg_captured = {}
+
+        def _fake_run_sdg_generation(taxonomy_df, **kwargs):
+            sdg_captured["taxonomy_concepts"] = taxonomy_df["policy_concept"].tolist()
+            return pd.DataFrame(
+                {
+                    "policy_concept": ["CustomHarm"],
+                    "concept_definition": ["Custom harm definition"],
+                    "prompt": ["Do something harmful"],
+                }
+            )
+
+        def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
+            report_prefix = scan_dir / "scan"
+            report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+            return module.GarakScanResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                report_prefix=report_prefix,
+            )
+
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.run_sdg_generation",
+            _fake_run_sdg_generation,
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.setup_and_run_garak",
+            _fake_setup_and_run,
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        adapter.run_benchmark_job(job, _Callbacks())
+        assert sdg_captured["taxonomy_concepts"] == ["CustomHarm"]
+
+    def test_simple_intents_bypass_sdg_from_local_path(self, monkeypatch, tmp_path):
+        """Bypass SDG: load pre-generated prompts from a local file."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        intents_file = tmp_path / "test_data" / "prompts.csv"
+        intents_file.parent.mkdir(parents=True, exist_ok=True)
+        intents_file.write_text(
+            "category,prompt,description\nharm,Do bad things,Harm prompts\n",
+            encoding="utf-8",
+        )
+        job.parameters["intents_s3_key"] = str(intents_file)
+
+        scan_dir = tmp_path / "simple-intents-job"
+        scan_dir.mkdir(parents=True, exist_ok=True)
+
+        setup_captured = {}
+
+        def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
+            import pandas as pd
+
+            setup_captured["prompts"] = pd.read_csv(prompts_csv_path)
+            report_prefix = scan_dir / "scan"
+            report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+            return module.GarakScanResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                report_prefix=report_prefix,
+            )
+
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.setup_and_run_garak",
+            _fake_setup_and_run,
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        adapter.run_benchmark_job(job, _Callbacks())
+
+        assert (scan_dir / "sdg_raw_output.csv").exists()
+        assert (scan_dir / "sdg_normalized_output.csv").exists()
+        assert len(setup_captured["prompts"]) == 1
+        assert setup_captured["prompts"]["category"].iloc[0] == "harm"
+
+    def test_simple_intents_missing_taxonomy_file_raises(self, monkeypatch, tmp_path):
+        """Missing taxonomy file raises FileNotFoundError."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+        job.parameters["policy_s3_key"] = "/nonexistent/taxonomy.csv"
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        with pytest.raises(Exception, match="Taxonomy file not found"):
+            adapter.run_benchmark_job(job, _Callbacks())
+
+    def test_simple_intents_missing_intents_file_raises(self, monkeypatch, tmp_path):
+        """Missing bypass prompts file raises FileNotFoundError."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+        job.parameters["intents_s3_key"] = "/nonexistent/prompts.csv"
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        with pytest.raises(Exception, match="Intents file not found"):
+            adapter.run_benchmark_job(job, _Callbacks())
+
+    def test_simple_intents_missing_sdg_model_raises(self, monkeypatch, tmp_path):
+        """SDG path without sdg_model raises ValueError."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        adapter = module.GarakAdapter()
+        monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
         job = SimpleNamespace(
-            id="intents-simple-job",
-            benchmark_id="trustyai_garak::intents_spo",
+            id="simple-intents-job",
+            benchmark_id="trustyai_garak::intents",
             benchmark_index=0,
-            model=SimpleNamespace(
-                url="http://localhost:8000",
-                name="test-model",
-            ),
+            model=SimpleNamespace(url="http://target:8000", name="target-llm"),
             parameters={
                 "execution_mode": "simple",
-                "art_intents": True,
+                "intents_models": {
+                    "judge": {"url": "http://judge:8000/v1", "name": "judge-model"},
+                    "attacker": {"url": "http://attacker:9000/v1", "name": "atk-model"},
+                    "evaluator": {"url": "http://evaluator:9001/v1", "name": "eval-model"},
+                },
             },
             exports=None,
         )
 
-        with pytest.raises(ValueError, match="Intents benchmarks are only supported in KFP"):
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        with pytest.raises(Exception, match="sdg_model.*sdg_api_base"):
             adapter.run_benchmark_job(job, _Callbacks())
+
+    def test_simple_intents_persists_artifacts_to_scan_dir(self, monkeypatch, tmp_path):
+        """Verify sdg_raw_output.csv and sdg_normalized_output.csv are in scan_dir."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        intents_file = tmp_path / "test_data" / "prompts.csv"
+        intents_file.parent.mkdir(parents=True, exist_ok=True)
+        intents_file.write_text(
+            "category,prompt,description\nfraud,Scam people,Fraud desc\nviolence,Attack,Violence desc\n",
+            encoding="utf-8",
+        )
+        job.parameters["intents_s3_key"] = str(intents_file)
+
+        scan_dir = tmp_path / "simple-intents-job"
+        scan_dir.mkdir(parents=True, exist_ok=True)
+
+        def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
+            report_prefix = scan_dir / "scan"
+            report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+            return module.GarakScanResult(
+                returncode=0,
+                stdout="",
+                stderr="",
+                report_prefix=report_prefix,
+            )
+
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.setup_and_run_garak",
+            _fake_setup_and_run,
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        adapter.run_benchmark_job(job, _Callbacks())
+
+        raw_csv = scan_dir / "sdg_raw_output.csv"
+        norm_csv = scan_dir / "sdg_normalized_output.csv"
+        assert raw_csv.exists()
+        assert norm_csv.exists()
+
+        import pandas as pd
+
+        norm_df = pd.read_csv(norm_csv)
+        assert "category" in norm_df.columns
+        assert "prompt" in norm_df.columns
+        assert len(norm_df) == 2
 
 
 class TestKFPIntentsMode:


### PR DESCRIPTION
Resolves [RHOAIENG-63138](https://redhat.atlassian.net/browse/RHOAIENG-63138)

## Testing Checklist

- [x] Unit tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] New/changed code has test coverage
- [x] No breaking changes to existing benchmark configs
- [ ] Documentation updated (if applicable)

## Summary by Sourcery

Enable intents benchmarks to run in simple (non-KFP) execution mode with an in-process SDG + Garak pipeline and corresponding tests.

New Features:
- Support running art_intents benchmarks in simple execution mode by dispatching to a dedicated _run_simple_intents pipeline.
- Add a simple-mode intents pipeline that resolves taxonomy data, optionally runs SDG or loads pre-generated prompts, normalizes prompts, and executes a local Garak scan.

Enhancements:
- Persist SDG raw and normalized outputs for intents runs to the scan directory for easier inspection and debugging.

Tests:
- Replace the previous KFP-only restriction test with a comprehensive test suite covering simple intents flows, including default taxonomy, custom taxonomy, SDG bypass, artifact persistence, and error conditions for missing files or SDG configuration.