### PR TITLE
fix: resolve S3 credential conflicts between kfp_config and k8s secret

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -617,21 +617,22 @@ class GarakAdapter(FrameworkAdapter):
                     "S3 credentials from secret '%s/%s' are empty. "
                     "Ensure the secret exists and the Job pod's service account "
                     "has RBAC permissions to read secrets in namespace '%s'. "
-                    "Falling back to environment variables for S3 access."
-                    "If no environment variables are set, the job will fail",
+                    "Falling back to environment variables for S3 access. "
+                    "If no environment variables are set, the job will fail "
                     "as it will not be able to interact with S3.",
                     kfp_config.namespace,
                     kfp_config.s3_secret_name,
                     kfp_config.namespace,
                 )
-            s3_bucket = kfp_config.s3_bucket or creds.pop("bucket", "") or os.getenv("AWS_S3_BUCKET", "")
-            s3_endpoint = kfp_config.s3_endpoint or creds.pop("endpoint_url", "") or None
+            resolved = self._resolve_s3_credentials(kfp_config, creds)
             self._download_results_from_s3(
-                s3_bucket,
+                resolved["bucket"],
                 s3_prefix,
                 scan_dir,
-                endpoint_url=s3_endpoint,
-                **creds,
+                endpoint_url=resolved["endpoint_url"],
+                access_key=resolved["access_key"],
+                secret_key=resolved["secret_key"],
+                region=resolved["region"],
             )
 
         report_prefix = scan_dir / "scan"
@@ -786,6 +787,49 @@ class GarakAdapter(FrameworkAdapter):
         except Exception as exc:
             logger.warning("Could not read S3 credentials from secret %s/%s: %s", namespace, secret_name, exc)
             return {}
+
+    @staticmethod
+    def _resolve_s3_credentials(kfp_config: "KFPConfig", secret_creds: dict) -> dict:
+        """Merge S3 credentials from KFPConfig, K8s secret, and env vars.
+
+        For each field, the first non-empty value wins:
+          1. kfp_config (benchmark_config / env override)
+          2. K8s secret (read via _read_s3_credentials_from_secret)
+          3. Environment variable (boto3 / Data Connection fallback)
+
+        When both kfp_config and the secret provide different non-empty
+        values for the same field, the kfp_config value is used and a
+        warning is logged so the operator can spot misconfigurations.
+        """
+        _FIELD_MAP: list[tuple[str, str, str]] = [
+            # (field_name, kfp_config_attr, env_var)
+            ("bucket", "s3_bucket", "AWS_S3_BUCKET"),
+            ("endpoint_url", "s3_endpoint", "AWS_S3_ENDPOINT"),
+        ]
+
+        resolved: dict[str, str | None] = {}
+
+        for field, kfp_attr, env_var in _FIELD_MAP:
+            cfg_val = (getattr(kfp_config, kfp_attr, "") or "").strip()
+            secret_val = (secret_creds.get(field, "") or "").strip()
+            env_val = (os.getenv(env_var, "") or "").strip()
+
+            if cfg_val and secret_val and cfg_val != secret_val:
+                logger.warning(
+                    "S3 %s mismatch: kfp_config=%r vs secret=%r — using kfp_config value. "
+                    "Check that kfp_config.%s and the Data Connection secret agree.",
+                    field,
+                    cfg_val,
+                    secret_val,
+                    kfp_attr,
+                )
+
+            resolved[field] = cfg_val or secret_val or env_val or None
+
+        for field in ("access_key", "secret_key", "region"):
+            resolved[field] = (secret_creds.get(field, "") or "").strip() or None
+
+        return resolved
 
     @staticmethod
     def _create_s3_client(

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -792,10 +792,15 @@ class GarakAdapter(FrameworkAdapter):
     def _resolve_s3_credentials(kfp_config: "KFPConfig", secret_creds: dict) -> dict:
         """Merge S3 credentials from KFPConfig, K8s secret, and env vars.
 
-        For each field, the first non-empty value wins:
+        For ``bucket`` and ``endpoint_url``, the first non-empty value wins:
           1. kfp_config (benchmark_config / env override)
           2. K8s secret (read via _read_s3_credentials_from_secret)
-          3. Environment variable (boto3 / Data Connection fallback)
+          3. Environment variable (``AWS_S3_BUCKET`` / ``AWS_S3_ENDPOINT``)
+
+        For ``access_key``, ``secret_key``, and ``region``, values come
+        only from the K8s secret.  These fields have no kfp_config
+        equivalent; when the secret is empty, ``create_s3_client``
+        applies its own env-var fallback (``AWS_ACCESS_KEY_ID``, etc.).
 
         When both kfp_config and the secret provide different non-empty
         values for the same field, the kfp_config value is used and a

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -807,17 +807,41 @@ class TestResolveS3Credentials:
         assert resolved["bucket"] == "env-bucket"
         assert resolved["endpoint_url"] == "http://env:9000"
 
+    def test_secret_takes_precedence_over_env_when_kfp_empty(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.setenv("AWS_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("AWS_S3_ENDPOINT", "http://env:9000")
+        secret = {
+            "bucket": "secret-bucket",
+            "endpoint_url": "http://secret:9000",
+            "access_key": "ak",
+            "secret_key": "sk",
+            "region": "eu-west-1",
+        }
+        kfp_cfg = self._make_kfp_config()
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+        assert resolved["bucket"] == "secret-bucket"
+        assert resolved["endpoint_url"] == "http://secret:9000"
+
     def test_mismatch_logs_warning(self, monkeypatch, caplog):
         module = _load_evalhub_garak_adapter(monkeypatch)
         import logging
 
-        kfp_cfg = self._make_kfp_config(s3_endpoint="http://cfg:9000")
-        secret = {"endpoint_url": "http://secret:9000", "bucket": "", "access_key": "", "secret_key": "", "region": ""}
+        kfp_cfg = self._make_kfp_config(s3_bucket="cfg-bucket", s3_endpoint="http://cfg:9000")
+        secret = {
+            "bucket": "secret-bucket",
+            "endpoint_url": "http://secret:9000",
+            "access_key": "",
+            "secret_key": "",
+            "region": "",
+        }
 
         with caplog.at_level(logging.WARNING):
             resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
 
+        assert resolved["bucket"] == "cfg-bucket"
         assert resolved["endpoint_url"] == "http://cfg:9000"
+        assert any("S3 bucket mismatch" in msg for msg in caplog.messages)
         assert any("S3 endpoint_url mismatch" in msg for msg in caplog.messages)
 
     def test_matching_values_no_warning(self, monkeypatch, caplog):

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -756,6 +756,99 @@ class TestS3Download:
         assert list(local_dir.iterdir()) == []
 
 
+class TestResolveS3Credentials:
+    """Tests for _resolve_s3_credentials merging logic."""
+
+    def _make_kfp_config(self, **overrides):
+        defaults = {
+            "s3_bucket": "",
+            "s3_endpoint": "",
+        }
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_kfp_config_takes_precedence_over_secret(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        kfp_cfg = self._make_kfp_config(s3_bucket="cfg-bucket", s3_endpoint="http://cfg:9000")
+        secret = {
+            "bucket": "secret-bucket",
+            "endpoint_url": "http://secret:9000",
+            "access_key": "ak",
+            "secret_key": "sk",
+            "region": "us-west-2",
+        }
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+        assert resolved["bucket"] == "cfg-bucket"
+        assert resolved["endpoint_url"] == "http://cfg:9000"
+        assert resolved["access_key"] == "ak"
+        assert resolved["secret_key"] == "sk"
+        assert resolved["region"] == "us-west-2"
+
+    def test_falls_back_to_secret_when_kfp_config_empty(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        kfp_cfg = self._make_kfp_config()
+        secret = {
+            "bucket": "secret-bucket",
+            "endpoint_url": "http://secret:9000",
+            "access_key": "ak",
+            "secret_key": "sk",
+            "region": "eu-west-1",
+        }
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+        assert resolved["bucket"] == "secret-bucket"
+        assert resolved["endpoint_url"] == "http://secret:9000"
+
+    def test_falls_back_to_env_when_both_empty(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.setenv("AWS_S3_BUCKET", "env-bucket")
+        monkeypatch.setenv("AWS_S3_ENDPOINT", "http://env:9000")
+        kfp_cfg = self._make_kfp_config()
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, {})
+        assert resolved["bucket"] == "env-bucket"
+        assert resolved["endpoint_url"] == "http://env:9000"
+
+    def test_mismatch_logs_warning(self, monkeypatch, caplog):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        import logging
+
+        kfp_cfg = self._make_kfp_config(s3_endpoint="http://cfg:9000")
+        secret = {"endpoint_url": "http://secret:9000", "bucket": "", "access_key": "", "secret_key": "", "region": ""}
+
+        with caplog.at_level(logging.WARNING):
+            resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+
+        assert resolved["endpoint_url"] == "http://cfg:9000"
+        assert any("S3 endpoint_url mismatch" in msg for msg in caplog.messages)
+
+    def test_matching_values_no_warning(self, monkeypatch, caplog):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        import logging
+
+        kfp_cfg = self._make_kfp_config(s3_bucket="same-bucket", s3_endpoint="http://same:9000")
+        secret = {
+            "bucket": "same-bucket",
+            "endpoint_url": "http://same:9000",
+            "access_key": "ak",
+            "secret_key": "sk",
+            "region": "",
+        }
+        with caplog.at_level(logging.WARNING):
+            resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+
+        assert resolved["bucket"] == "same-bucket"
+        assert not any("mismatch" in msg for msg in caplog.messages)
+
+    def test_none_returned_when_all_sources_empty(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.delenv("AWS_S3_BUCKET", raising=False)
+        monkeypatch.delenv("AWS_S3_ENDPOINT", raising=False)
+        kfp_cfg = self._make_kfp_config()
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, {})
+        assert resolved["bucket"] is None
+        assert resolved["endpoint_url"] is None
+        assert resolved["access_key"] is None
+
+
 class TestPollKFPRun:
     """Tests for _poll_kfp_run static method."""
 


### PR DESCRIPTION
Resolves [RHOAIENG-63348](https://redhat.atlassian.net/browse/RHOAIENG-63348)

## Testing Checklist

- [x] Unit tests pass (`make test`)
- [x] Linting passes (`make lint`)
- [x] New/changed code has test coverage
- [x] No breaking changes to existing benchmark configs
- [ ] Documentation updated (if applicable)

## Summary by Sourcery

Resolve S3 credential source precedence and centralize merging logic for KFP runs.

Bug Fixes:
- Ensure KFP configuration values for S3 bucket and endpoint take precedence over conflicting Kubernetes secret values while still using secret-based access credentials.
- Provide a deterministic fallback order for S3 bucket and endpoint resolution from KFP config, Kubernetes secret, and environment variables, returning None when all sources are empty.
- Emit warnings when KFP configuration and secret provide mismatched non-empty S3 settings, avoiding warnings when they match.

Tests:
- Add unit test coverage for S3 credential resolution precedence, fallbacks to secrets and environment variables, mismatch warning behavior, and all-empty handling.