### PR TITLE
fix: evalhub >= 0.4.4 sidecar-proxy compatibility for KFP mode

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1579,9 +1579,7 @@ class GarakAdapter(FrameworkAdapter):
             for role in ("judge", "attacker", "evaluator"):
                 role_url = (intents_models.get(role) or {}).get("url", "").strip()
                 if role_url and not GarakAdapter._is_sidecar_address(role_url):
-                    logger.info(
-                        "Resolved model URL from intents_models.%s: %s", role, role_url
-                    )
+                    logger.info("Resolved model URL from intents_models.%s: %s", role, role_url)
                     return role_url.rstrip("/")
 
         if kfp_overrides:

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -828,22 +828,48 @@ class GarakAdapter(FrameworkAdapter):
 
     @staticmethod
     def _create_kfp_client(kfp_config: "KFPConfig"):
-        """Create a KFP Client from KFPConfig."""
+        """Create a KFP Client from KFPConfig.
+
+        Since evalhub PR #672 the adapter pod runs with
+        AutomountServiceAccountToken=false. The standard SA token path
+        (/var/run/secrets/kubernetes.io/serviceaccount/token) is no longer
+        present — only a DownwardAPI namespace file is mounted there. Auth
+        must come from KFP_AUTH_TOKEN / kfp_config.auth_token instead.
+        """
         from kfp import Client
 
         ssl_ca_cert = kfp_config.ssl_ca_cert or None
         token = kfp_config.auth_token or None
 
-        # If no explicit token, try to get one from the cluster service account
         if not token:
             sa_token_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
             if sa_token_path.exists():
-                token = sa_token_path.read_text().strip()
-                logger.debug("Using service account token for KFP auth")
+                candidate = sa_token_path.read_text().strip()
+                # evalhub >= 0.4.4 (PR #672) mounts a DownwardAPI *namespace* file at
+                # the same standard SA path instead of the real token. Guard against
+                # mistaking it for a JWT — all real SA tokens are base64url-encoded
+                # JSON and start with "eyJ".
+                if candidate.startswith("eyJ"):
+                    token = candidate
+                    logger.debug("Using service account token for KFP auth")
+                else:
+                    logger.debug(
+                        "SA token path contains a non-JWT value (evalhub >= 0.4.4 "
+                        "DownwardAPI namespace file); ignoring. Set KFP_AUTH_TOKEN "
+                        "for explicit authentication."
+                    )
+
+        if not token:
+            logger.warning(
+                "No KFP auth token available. Set KFP_AUTH_TOKEN or "
+                "kfp_config.auth_token. Proceeding without authentication — "
+                "this will fail on clusters that require a bearer token."
+            )
 
         return Client(
             host=kfp_config.endpoint,
             existing_token=token,
+            namespace=kfp_config.namespace,
             verify_ssl=kfp_config.verify_ssl,
             ssl_ca_cert=ssl_ca_cert,
         )
@@ -948,8 +974,21 @@ class GarakAdapter(FrameworkAdapter):
 
             try:
                 k8s_config.load_incluster_config()
-            except Exception:
-                k8s_config.load_kube_config()
+            except k8s_config.ConfigException:
+                # evalhub PR #672: SA token is no longer auto-mounted on the adapter
+                # pod. Try authenticating via KFP_AUTH_TOKEN (already required for
+                # KFP client auth), then fall back to kubeconfig for local dev.
+                auth_token = os.getenv("KFP_AUTH_TOKEN", "")
+                k8s_host = os.getenv("KUBERNETES_SERVICE_HOST", "")
+                k8s_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+                if auth_token and k8s_host:
+                    configuration = k8s_client.Configuration()
+                    configuration.host = f"https://{k8s_host}:{k8s_port}"
+                    configuration.api_key = {"authorization": f"Bearer {auth_token}"}
+                    configuration.verify_ssl = False
+                    k8s_client.Configuration.set_default(configuration)
+                else:
+                    k8s_config.load_kube_config()
             v1 = k8s_client.CoreV1Api()
             secret = v1.read_namespaced_secret(secret_name, namespace)
             data = secret.data or {}

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1195,8 +1195,15 @@ class GarakAdapter(FrameworkAdapter):
                 or os.getenv("OPENAICOMPATIBLE_API_KEY")
                 or "DUMMY"
             )
+            # kfp_config.model_url is an explicit override for the target model URL
+            # used in KFP component pods (which have no sidecar proxy). Required when
+            # evalhub >= 0.4.4 rewrites job.json to localhost:8080 and the real URL
+            # cannot be resolved automatically from sidecar_config.json.
+            kfp_overrides = benchmark_config.get("kfp_config", {}) or {}
+            explicit_model_url = (kfp_overrides.get("model_url") or "").strip()
+            raw_model_url = explicit_model_url or self._resolve_real_model_url(config.model.url)
             garak_config.plugins.generators = build_generator_options(
-                model_endpoint=self._normalize_url(self._resolve_real_model_url(config.model.url)),
+                model_endpoint=self._normalize_url(raw_model_url),
                 model_name=config.model.name,
                 api_key=api_key,
                 extra_params=model_params or TARGET_DEFAULT_PARAMETERS,
@@ -1541,28 +1548,52 @@ class GarakAdapter(FrameworkAdapter):
         garak runs inside the adapter pod where the sidecar is present, but in
         KFP mode garak runs in a separate KFP component pod that has no sidecar.
 
-        When the URL looks like a sidecar address we read the real upstream URL
-        from /meta/sidecar_config.json, which evalhub writes alongside job.json.
-        Falls back to model_url unchanged if the file is absent or unreadable
-        (old evalhub, local dev, or non-sidecar deployments).
+        When the URL looks like a sidecar address we attempt to read the real
+        upstream URL from the evalhub sidecar config file (written alongside
+        job.json). Several key-name conventions are tried to handle different
+        evalhub versions. Falls back to model_url unchanged when the file is
+        absent or unreadable (old evalhub, local dev, non-sidecar deployments).
+
+        If this method is still returning localhost:8080 after upgrade, set
+        kfp_config.model_url in benchmark_config as an explicit override.
         """
         parsed = model_url.strip().rstrip("/")
         # Only attempt the lookup when the URL is a loopback sidecar address.
         if not ("localhost" in parsed or "127.0.0.1" in parsed):
             return parsed
 
-        sidecar_cfg_path = Path(os.getenv("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")).parent / "sidecar_config.json"
-        try:
-            cfg = json.loads(sidecar_cfg_path.read_text())
-            real_url = cfg.get("model", {}).get("url", "").strip().rstrip("/")
-            if real_url:
-                logger.debug("Resolved real model URL from %s: %s", sidecar_cfg_path, real_url)
-                return real_url
-        except FileNotFoundError:
-            logger.debug("sidecar_config.json not found at %s; using model URL as-is", sidecar_cfg_path)
-        except Exception as exc:
-            logger.warning("Could not read sidecar_config.json: %s; using model URL as-is", exc)
+        meta_dir = Path(os.getenv("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")).parent
+        candidate_paths = [
+            meta_dir / "sidecar_config.json",
+            meta_dir / "sidecar-config.json",
+            Path("/etc/eval-sidecar/config.json"),
+        ]
+        # Key-name pairs to try in order (Go JSON tags vary by evalhub version).
+        key_pairs = [("model", "url"), ("Model", "URL"), ("model", "URL"), ("Model", "url")]
 
+        for cfg_path in candidate_paths:
+            try:
+                cfg = json.loads(cfg_path.read_text())
+            except FileNotFoundError:
+                continue
+            except Exception as exc:
+                logger.warning("Could not parse %s: %s", cfg_path, exc)
+                continue
+
+            for model_key, url_key in key_pairs:
+                real_url = (cfg.get(model_key) or {}).get(url_key, "")
+                if real_url:
+                    real_url = real_url.strip().rstrip("/")
+                    logger.info("Resolved real model URL from %s: %s", cfg_path, real_url)
+                    return real_url
+
+        logger.warning(
+            "Model URL is a sidecar address (%s) but the real URL could not be "
+            "resolved from any sidecar config file. KFP component pods have no "
+            "sidecar — set kfp_config.model_url in benchmark_config to provide "
+            "the real model URL explicitly.",
+            parsed,
+        )
         return parsed
 
     # def _build_environment(self, config: JobSpec) -> dict[str, str]:

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1195,13 +1195,7 @@ class GarakAdapter(FrameworkAdapter):
                 or os.getenv("OPENAICOMPATIBLE_API_KEY")
                 or "DUMMY"
             )
-            # kfp_config.model_url is an explicit override for the target model URL
-            # used in KFP component pods (which have no sidecar proxy). Required when
-            # evalhub >= 0.4.4 rewrites job.json to localhost:8080 and the real URL
-            # cannot be resolved automatically from sidecar_config.json.
-            kfp_overrides = benchmark_config.get("kfp_config", {}) or {}
-            explicit_model_url = (kfp_overrides.get("model_url") or "").strip()
-            raw_model_url = explicit_model_url or self._resolve_real_model_url(config.model.url)
+            raw_model_url = self._resolve_kfp_model_url(config.model.url, benchmark_config)
             garak_config.plugins.generators = build_generator_options(
                 model_endpoint=self._normalize_url(raw_model_url),
                 model_name=config.model.name,
@@ -1540,61 +1534,66 @@ class GarakAdapter(FrameworkAdapter):
         return url
 
     @staticmethod
-    def _resolve_real_model_url(model_url: str) -> str:
-        """Return the real upstream model URL for use in KFP component pods.
+    def _is_sidecar_address(url: str) -> bool:
+        return "localhost" in url or "127.0.0.1" in url
 
-        After evalhub PR #676 job.json always carries http://localhost:8080 as
-        the model URL (the sidecar address). That works in simple mode because
-        garak runs inside the adapter pod where the sidecar is present, but in
-        KFP mode garak runs in a separate KFP component pod that has no sidecar.
+    @staticmethod
+    def _resolve_kfp_model_url(model_url: str, benchmark_config: dict) -> str:
+        """Resolve the target model URL for KFP component pods.
 
-        When the URL looks like a sidecar address we attempt to read the real
-        upstream URL from the evalhub sidecar config file (written alongside
-        job.json). Several key-name conventions are tried to handle different
-        evalhub versions. Falls back to model_url unchanged when the file is
-        absent or unreadable (old evalhub, local dev, non-sidecar deployments).
+        evalhub >= 0.4.4 rewrites job.json so model.url points at the
+        sidecar proxy (localhost:8080).  That works in simple mode (sidecar
+        is co-located) but KFP component pods have no sidecar.
 
-        If this method is still returning localhost:8080 after upgrade, set
-        kfp_config.model_url in benchmark_config as an explicit override.
+        Resolution chain (first non-sidecar URL wins):
+        1. kfp_config.model_url   — explicit override in benchmark_config
+        2. model auth secret key  — read_model_auth_key("model_url")
+        3. intents_models.*.url   — first non-localhost URL from
+           judge/attacker/evaluator config
+        4. model_url as-is        — fallback (works for simple mode and
+           pre-sidecar evalhub)
         """
-        parsed = model_url.strip().rstrip("/")
-        # Only attempt the lookup when the URL is a loopback sidecar address.
-        if not ("localhost" in parsed or "127.0.0.1" in parsed):
-            return parsed
+        url = model_url.strip().rstrip("/")
 
-        meta_dir = Path(os.getenv("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")).parent
-        candidate_paths = [
-            meta_dir / "sidecar_config.json",
-            meta_dir / "sidecar-config.json",
-            Path("/etc/eval-sidecar/config.json"),
-        ]
-        # Key-name pairs to try in order (Go JSON tags vary by evalhub version).
-        key_pairs = [("model", "url"), ("Model", "URL"), ("model", "URL"), ("Model", "url")]
+        if not GarakAdapter._is_sidecar_address(url):
+            return url
 
-        for cfg_path in candidate_paths:
-            try:
-                cfg = json.loads(cfg_path.read_text())
-            except FileNotFoundError:
-                continue
-            except Exception as exc:
-                logger.warning("Could not parse %s: %s", cfg_path, exc)
-                continue
+        kfp_overrides = benchmark_config.get("kfp_config", {}) or {}
+        explicit = (kfp_overrides.get("model_url") or "").strip()
+        if explicit:
+            logger.info("Using explicit kfp_config.model_url: %s", explicit)
+            return explicit.rstrip("/")
 
-            for model_key, url_key in key_pairs:
-                real_url = (cfg.get(model_key) or {}).get(url_key, "")
-                if real_url:
-                    real_url = real_url.strip().rstrip("/")
-                    logger.info("Resolved real model URL from %s: %s", cfg_path, real_url)
-                    return real_url
+        try:
+            from evalhub.adapter.auth import read_model_auth_key
 
-        logger.warning(
-            "Model URL is a sidecar address (%s) but the real URL could not be "
-            "resolved from any sidecar config file. KFP component pods have no "
-            "sidecar — set kfp_config.model_url in benchmark_config to provide "
-            "the real model URL explicitly.",
-            parsed,
-        )
-        return parsed
+            secret_url = (read_model_auth_key("model_url") or "").strip()
+            if secret_url and not GarakAdapter._is_sidecar_address(secret_url):
+                logger.info("Resolved model URL from model auth secret: %s", secret_url)
+                return secret_url.rstrip("/")
+        except Exception:
+            pass
+
+        intents_models = benchmark_config.get("intents_models", {})
+        if isinstance(intents_models, dict):
+            for role in ("judge", "attacker", "evaluator"):
+                role_url = (intents_models.get(role) or {}).get("url", "").strip()
+                if role_url and not GarakAdapter._is_sidecar_address(role_url):
+                    logger.info(
+                        "Resolved model URL from intents_models.%s: %s", role, role_url
+                    )
+                    return role_url.rstrip("/")
+
+        if kfp_overrides:
+            logger.warning(
+                "Model URL is a sidecar address (%s) but could not be resolved "
+                "to a real upstream URL. KFP component pods have no sidecar "
+                "proxy. Set kfp_config.model_url in benchmark_config or add a "
+                "model_url key to the model auth secret.",
+                url,
+            )
+
+        return url
 
     # def _build_environment(self, config: JobSpec) -> dict[str, str]:
     #     """Build environment variables for Garak execution."""

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1196,7 +1196,7 @@ class GarakAdapter(FrameworkAdapter):
                 or "DUMMY"
             )
             garak_config.plugins.generators = build_generator_options(
-                model_endpoint=self._normalize_url(config.model.url),
+                model_endpoint=self._normalize_url(self._resolve_real_model_url(config.model.url)),
                 model_name=config.model.name,
                 api_key=api_key,
                 extra_params=model_params or TARGET_DEFAULT_PARAMETERS,
@@ -1531,6 +1531,39 @@ class GarakAdapter(FrameworkAdapter):
         if not re.match(r"^.*\/v\d+$", url):
             url = f"{url}/v1"
         return url
+
+    @staticmethod
+    def _resolve_real_model_url(model_url: str) -> str:
+        """Return the real upstream model URL for use in KFP component pods.
+
+        After evalhub PR #676 job.json always carries http://localhost:8080 as
+        the model URL (the sidecar address). That works in simple mode because
+        garak runs inside the adapter pod where the sidecar is present, but in
+        KFP mode garak runs in a separate KFP component pod that has no sidecar.
+
+        When the URL looks like a sidecar address we read the real upstream URL
+        from /meta/sidecar_config.json, which evalhub writes alongside job.json.
+        Falls back to model_url unchanged if the file is absent or unreadable
+        (old evalhub, local dev, or non-sidecar deployments).
+        """
+        parsed = model_url.strip().rstrip("/")
+        # Only attempt the lookup when the URL is a loopback sidecar address.
+        if not ("localhost" in parsed or "127.0.0.1" in parsed):
+            return parsed
+
+        sidecar_cfg_path = Path(os.getenv("EVALHUB_JOB_SPEC_PATH", "/meta/job.json")).parent / "sidecar_config.json"
+        try:
+            cfg = json.loads(sidecar_cfg_path.read_text())
+            real_url = cfg.get("model", {}).get("url", "").strip().rstrip("/")
+            if real_url:
+                logger.debug("Resolved real model URL from %s: %s", sidecar_cfg_path, real_url)
+                return real_url
+        except FileNotFoundError:
+            logger.debug("sidecar_config.json not found at %s; using model URL as-is", sidecar_cfg_path)
+        except Exception as exc:
+            logger.warning("Could not read sidecar_config.json: %s; using model URL as-is", exc)
+
+        return parsed
 
     # def _build_environment(self, config: JobSpec) -> dict[str, str]:
     #     """Build environment variables for Garak execution."""

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -830,41 +830,33 @@ class GarakAdapter(FrameworkAdapter):
     def _create_kfp_client(kfp_config: "KFPConfig"):
         """Create a KFP Client from KFPConfig.
 
-        Since evalhub PR #672 the adapter pod runs with
-        AutomountServiceAccountToken=false. The standard SA token path
-        (/var/run/secrets/kubernetes.io/serviceaccount/token) is no longer
-        present — only a DownwardAPI namespace file is mounted there. Auth
-        must come from KFP_AUTH_TOKEN / kfp_config.auth_token instead.
+        Two auth models are supported:
+
+        **Old model (evalhub < 0.4.4 / direct KFP)**: the full SA token is
+        auto-mounted at the standard path; this method reads it and passes it
+        to the client. KFP_ENDPOINT points at the real KFP API URL.
+
+        **New model (evalhub >= 0.4.4 / sidecar proxy)**: evalhub PR #672 sets
+        AutomountServiceAccountToken=false on the adapter pod. The SA token
+        file no longer exists, so ``token`` stays None — which is correct
+        because KFP_ENDPOINT must be set to ``localhost:8080`` and the sidecar
+        proxy injects the SA token on every outbound request automatically.
+        namespace is always passed explicitly so the KFP SDK never needs to
+        call get_kfp_healthz to auto-detect it.
         """
         from kfp import Client
 
         ssl_ca_cert = kfp_config.ssl_ca_cert or None
         token = kfp_config.auth_token or None
 
+        # Old model: SA token file is present — read it for direct KFP auth.
+        # New model: file does not exist (only DownwardAPI namespace file is
+        # mounted); token stays None and the sidecar injects auth instead.
         if not token:
             sa_token_path = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
             if sa_token_path.exists():
-                candidate = sa_token_path.read_text().strip()
-                # evalhub >= 0.4.4 (PR #672) mounts a DownwardAPI *namespace* file at
-                # the same standard SA path instead of the real token. Guard against
-                # mistaking it for a JWT — all real SA tokens are base64url-encoded
-                # JSON and start with "eyJ".
-                if candidate.startswith("eyJ"):
-                    token = candidate
-                    logger.debug("Using service account token for KFP auth")
-                else:
-                    logger.debug(
-                        "SA token path contains a non-JWT value (evalhub >= 0.4.4 "
-                        "DownwardAPI namespace file); ignoring. Set KFP_AUTH_TOKEN "
-                        "for explicit authentication."
-                    )
-
-        if not token:
-            logger.warning(
-                "No KFP auth token available. Set KFP_AUTH_TOKEN or "
-                "kfp_config.auth_token. Proceeding without authentication — "
-                "this will fail on clusters that require a bearer token."
-            )
+                token = sa_token_path.read_text().strip()
+                logger.debug("Using service account token for KFP auth")
 
         return Client(
             host=kfp_config.endpoint,

--- a/src/llama_stack_provider_trustyai_garak/evalhub/kfp_pipeline.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/kfp_pipeline.py
@@ -78,23 +78,44 @@ class KFPConfig:
     def from_env_and_config(cls, benchmark_config: dict | None = None) -> "KFPConfig":
         """Build KFPConfig from env vars, with benchmark_config overrides.
 
-        Env var precedence (lowest to highest):
+        Resolution precedence (lowest to highest):
         1. Dataclass defaults
-        2. Environment variables (KFP_*)
-        3. benchmark_config dict keys
+        2. Model auth secret keys read via evalhub read_model_auth_key
+           (new sidecar-proxy model — evalhub >= 0.4.4):
+           - ``kfp_url``      → read_model_auth_key returns ``http://localhost:8080``
+           - ``kfp_sa_token`` → read_model_auth_key returns ``kfp_sa_token:ref``
+             (a placeholder the sidecar swaps with the real SA token on every request)
+        3. Environment variables (KFP_*)
+        4. benchmark_config dict keys
         """
         bc = benchmark_config or {}
         kfp_overrides = bc.get("kfp_config", {})
         if not isinstance(kfp_overrides, dict):
             kfp_overrides = {}
 
+        # New sidecar-proxy model (evalhub >= 0.4.4): KFP connection details
+        # come from the model auth secret rather than env vars. The secret key
+        # names use the operator-chosen prefix (default: "kfp") followed by
+        # "_url" and "_sa_token". read_model_auth_key resolves the mounted
+        # secret file and returns the placeholder ref for the sidecar to swap.
+        _secret_kfp_url = ""
+        _secret_kfp_token = ""
+        try:
+            from evalhub.adapter.auth import read_model_auth_key
+
+            _secret_kfp_url = read_model_auth_key("kfp_url") or ""
+            _secret_kfp_token = read_model_auth_key("kfp_sa_token") or ""
+        except Exception:
+            pass
+
         def _resolve(key: str, env_var: str, default: str = "") -> str:
             return str(kfp_overrides.get(key, os.getenv(env_var, default)))
 
-        endpoint = _resolve("endpoint", "KFP_ENDPOINT")
+        endpoint = _resolve("endpoint", "KFP_ENDPOINT", _secret_kfp_url)
         if not endpoint:
             raise ValueError(
-                "KFP endpoint is required. Set KFP_ENDPOINT or provide kfp_config.endpoint in benchmark_config."
+                "KFP endpoint is required. Set KFP_ENDPOINT, provide kfp_config.endpoint "
+                "in benchmark_config, or add a kfp_url key to the model auth secret."
             )
 
         namespace = _resolve("namespace", "KFP_NAMESPACE")
@@ -109,7 +130,7 @@ class KFPConfig:
         return cls(
             endpoint=endpoint,
             namespace=namespace,
-            auth_token=_resolve("auth_token", "KFP_AUTH_TOKEN"),
+            auth_token=_resolve("auth_token", "KFP_AUTH_TOKEN", _secret_kfp_token),
             s3_secret_name=_resolve("s3_secret_name", "KFP_S3_SECRET_NAME"),
             s3_bucket=_resolve("s3_bucket", "AWS_S3_BUCKET"),
             s3_endpoint=_resolve("s3_endpoint", "AWS_S3_ENDPOINT"),

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -3775,28 +3775,22 @@ class TestResolveKfpModelUrl:
 
     def test_non_localhost_url_passes_through(self, monkeypatch):
         module = _load_evalhub_garak_adapter(monkeypatch)
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "https://model.example.com/v1", {}
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("https://model.example.com/v1", {})
         assert result == "https://model.example.com/v1"
 
     def test_explicit_kfp_config_model_url_wins(self, monkeypatch):
         module = _load_evalhub_garak_adapter(monkeypatch)
         bc = {"kfp_config": {"model_url": "https://override.example.com/v1"}}
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://localhost:8080", bc
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", bc)
         assert result == "https://override.example.com/v1"
 
     def test_model_auth_secret_fallback(self, monkeypatch):
         module = _load_evalhub_garak_adapter(monkeypatch)
         auth_mod = sys.modules["evalhub.adapter.auth"]
-        auth_mod.read_model_auth_key = (
-            lambda name: "https://from-secret.example.com/v1" if name == "model_url" else None
+        auth_mod.read_model_auth_key = lambda name: (
+            "https://from-secret.example.com/v1" if name == "model_url" else None
         )
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://localhost:8080", {}
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", {})
         assert result == "https://from-secret.example.com/v1"
 
     def test_intents_models_judge_fallback(self, monkeypatch):
@@ -3806,9 +3800,7 @@ class TestResolveKfpModelUrl:
                 "judge": {"url": "https://judge.example.com/v1", "name": "j"},
             }
         }
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://localhost:8080", bc
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", bc)
         assert result == "https://judge.example.com/v1"
 
     def test_intents_models_skips_localhost_urls(self, monkeypatch):
@@ -3819,16 +3811,12 @@ class TestResolveKfpModelUrl:
                 "attacker": {"url": "https://real-attacker.example.com/v1", "name": "a"},
             }
         }
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://localhost:8080", bc
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", bc)
         assert result == "https://real-attacker.example.com/v1"
 
     def test_returns_localhost_when_no_fallbacks(self, monkeypatch):
         module = _load_evalhub_garak_adapter(monkeypatch)
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://localhost:8080", {}
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", {})
         assert result == "http://localhost:8080"
 
     def test_warns_when_localhost_remains_in_kfp_mode(self, monkeypatch, caplog):
@@ -3837,9 +3825,7 @@ class TestResolveKfpModelUrl:
         module = _load_evalhub_garak_adapter(monkeypatch)
         bc = {"kfp_config": {"namespace": "test-ns"}}
         with caplog.at_level(logging.WARNING):
-            result = module.GarakAdapter._resolve_kfp_model_url(
-                "http://localhost:8080", bc
-            )
+            result = module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", bc)
         assert result == "http://localhost:8080"
         assert "sidecar address" in caplog.text
         assert "kfp_config.model_url" in caplog.text
@@ -3849,17 +3835,13 @@ class TestResolveKfpModelUrl:
 
         module = _load_evalhub_garak_adapter(monkeypatch)
         with caplog.at_level(logging.WARNING):
-            module.GarakAdapter._resolve_kfp_model_url(
-                "http://localhost:8080", {}
-            )
+            module.GarakAdapter._resolve_kfp_model_url("http://localhost:8080", {})
         assert "sidecar address" not in caplog.text
 
     def test_127_0_0_1_treated_as_sidecar(self, monkeypatch):
         module = _load_evalhub_garak_adapter(monkeypatch)
         bc = {"kfp_config": {"model_url": "https://real.example.com"}}
-        result = module.GarakAdapter._resolve_kfp_model_url(
-            "http://127.0.0.1:8080/v1", bc
-        )
+        result = module.GarakAdapter._resolve_kfp_model_url("http://127.0.0.1:8080/v1", bc)
         assert result == "https://real.example.com"
 
     def test_end_to_end_generator_uses_intents_url(self, monkeypatch, tmp_path):

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -3768,3 +3768,149 @@ class TestWriteKfpOutputsComponent:
 
         html_content = Path(html.path).read_text()
         assert "Report generation failed" in html_content
+
+
+class TestResolveKfpModelUrl:
+    """Tests for _resolve_kfp_model_url model URL resolution chain."""
+
+    def test_non_localhost_url_passes_through(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "https://model.example.com/v1", {}
+        )
+        assert result == "https://model.example.com/v1"
+
+    def test_explicit_kfp_config_model_url_wins(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        bc = {"kfp_config": {"model_url": "https://override.example.com/v1"}}
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://localhost:8080", bc
+        )
+        assert result == "https://override.example.com/v1"
+
+    def test_model_auth_secret_fallback(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        auth_mod = sys.modules["evalhub.adapter.auth"]
+        auth_mod.read_model_auth_key = (
+            lambda name: "https://from-secret.example.com/v1" if name == "model_url" else None
+        )
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://localhost:8080", {}
+        )
+        assert result == "https://from-secret.example.com/v1"
+
+    def test_intents_models_judge_fallback(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        bc = {
+            "intents_models": {
+                "judge": {"url": "https://judge.example.com/v1", "name": "j"},
+            }
+        }
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://localhost:8080", bc
+        )
+        assert result == "https://judge.example.com/v1"
+
+    def test_intents_models_skips_localhost_urls(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        bc = {
+            "intents_models": {
+                "judge": {"url": "http://localhost:8080/v1", "name": "j"},
+                "attacker": {"url": "https://real-attacker.example.com/v1", "name": "a"},
+            }
+        }
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://localhost:8080", bc
+        )
+        assert result == "https://real-attacker.example.com/v1"
+
+    def test_returns_localhost_when_no_fallbacks(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://localhost:8080", {}
+        )
+        assert result == "http://localhost:8080"
+
+    def test_warns_when_localhost_remains_in_kfp_mode(self, monkeypatch, caplog):
+        import logging
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        bc = {"kfp_config": {"namespace": "test-ns"}}
+        with caplog.at_level(logging.WARNING):
+            result = module.GarakAdapter._resolve_kfp_model_url(
+                "http://localhost:8080", bc
+            )
+        assert result == "http://localhost:8080"
+        assert "sidecar address" in caplog.text
+        assert "kfp_config.model_url" in caplog.text
+
+    def test_no_warning_without_kfp_config(self, monkeypatch, caplog):
+        import logging
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        with caplog.at_level(logging.WARNING):
+            module.GarakAdapter._resolve_kfp_model_url(
+                "http://localhost:8080", {}
+            )
+        assert "sidecar address" not in caplog.text
+
+    def test_127_0_0_1_treated_as_sidecar(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        bc = {"kfp_config": {"model_url": "https://real.example.com"}}
+        result = module.GarakAdapter._resolve_kfp_model_url(
+            "http://127.0.0.1:8080/v1", bc
+        )
+        assert result == "https://real.example.com"
+
+    def test_end_to_end_generator_uses_intents_url(self, monkeypatch, tmp_path):
+        """When model.url is localhost and intents_models has a real URL,
+        the generator URI in the final config should use the intents URL."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        adapter = module.GarakAdapter()
+        monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
+        job = SimpleNamespace(
+            id="kfp-sidecar-job",
+            benchmark_id="trustyai_garak::intents",
+            benchmark_index=0,
+            model=SimpleNamespace(url="http://localhost:8080", name="my-model"),
+            parameters={
+                **_INTENTS_MODELS_SINGLE,
+                "kfp_config": {"namespace": "test-ns"},
+            },
+            exports=None,
+        )
+
+        report_prefix = tmp_path / "scan"
+        config_dict, _, _ = adapter._build_config_from_spec(job, report_prefix)
+
+        generator_uri = config_dict["plugins"]["generators"]["openai"]["OpenAICompatible"]["uri"]
+        assert "localhost" not in generator_uri
+        assert generator_uri == "http://judge:8000/v1"
+
+    def test_precedence_kfp_config_over_intents_models(self, monkeypatch, tmp_path):
+        """kfp_config.model_url should take precedence over intents_models."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        adapter = module.GarakAdapter()
+        monkeypatch.setenv("GARAK_SCAN_DIR", str(tmp_path))
+
+        job = SimpleNamespace(
+            id="kfp-explicit-job",
+            benchmark_id="trustyai_garak::intents",
+            benchmark_index=0,
+            model=SimpleNamespace(url="http://localhost:8080", name="my-model"),
+            parameters={
+                **_INTENTS_MODELS_SINGLE,
+                "kfp_config": {
+                    "namespace": "test-ns",
+                    "model_url": "https://explicit-override.example.com/v1",
+                },
+            },
+            exports=None,
+        )
+
+        report_prefix = tmp_path / "scan"
+        config_dict, _, _ = adapter._build_config_from_spec(job, report_prefix)
+
+        generator_uri = config_dict["plugins"]["generators"]["openai"]["OpenAICompatible"]["uri"]
+        assert generator_uri == "https://explicit-override.example.com/v1"


### PR DESCRIPTION
## Background

EvalHub >= 0.4.4 introduces a sidecar proxy architecture that changes how the adapter pod authenticates and routes requests:

- [eval-hub/eval-hub#672](https://github.com/eval-hub/eval-hub/pull/672) — sets `AutomountServiceAccountToken: false` on the adapter pod; the SA token is now exclusive to the sidecar container.
- [eval-hub/eval-hub#676](https://github.com/eval-hub/eval-hub/pull/676) — rewrites `job.json` so `model.url` always points at `http://localhost:8080` (the sidecar proxy), instead of the real upstream model endpoint.
- [eval-hub/eval-hub#681](https://github.com/eval-hub/eval-hub/pull/681) — adds `*_sa_token` / `*_url` secret key conventions. The adapter receives `kfp_sa_token:ref` and `http://localhost:8080` as KFP credentials; the sidecar resolves the ref, injects the pod SA token, and routes to the real KFP URL.

This broke the garak adapter in two ways:

1. **KFP client auth**: the adapter could no longer authenticate to the KFP API (no SA token, no auto-detected namespace → 401 Unauthorized).
2. **KFP generator model URL**: the garak config for KFP component pods contained `http://localhost:8080/v1` as the target model URI. KFP pods have no sidecar, so garak couldn't reach the model.

## Changes

### KFP client auth (`_create_kfp_client`)

- Reads `kfp_sa_token` and `kfp_url` from the model auth secret via `read_model_auth_key()` — the sidecar proxy resolves these refs and routes requests to the real KFP API.
- Passes `namespace` explicitly to `kfp.Client()` to avoid `get_kfp_healthz` auto-detection (which fails without a direct SA token).
- Falls back to the standard SA token file for old evalhub versions (pre-sidecar).

### KFP endpoint resolution (`KFPConfig.from_env_and_config`)

Resolution precedence (lowest → highest):
1. Dataclass defaults
2. Model auth secret keys (`kfp_url`, `kfp_sa_token`)
3. Environment variables (`KFP_ENDPOINT`, `KFP_AUTH_TOKEN`)
4. `benchmark_config.kfp_config` overrides

### S3 credential access (`_read_s3_credentials_from_secret`)

- Catches `ConfigException` specifically (not generic `Exception`) when `load_incluster_config()` fails.
- Falls back to `KFP_AUTH_TOKEN` + `KUBERNETES_SERVICE_HOST` for K8s API access when the SA token isn't mounted.

### Model URL resolution for KFP pods (`_resolve_kfp_model_url`)

This is the core fix for the `localhost:8080` generator URI problem. When `config.model.url` is a sidecar address (`localhost` / `127.0.0.1`), the method resolves the real upstream URL using a cascading chain:

1. **`kfp_config.model_url`** — explicit override in `benchmark_config` (highest priority)
2. **`read_model_auth_key("model_url")`** — from the model auth secret (future-proofs for evalhub adding this key)
3. **`intents_models.*.url`** — first non-localhost URL from judge/attacker/evaluator config (covers the common case where target model = intents model)
4. **`config.model.url`** — original value (fallback; works for simple mode where sidecar is present)

Replaces the previous `_resolve_real_model_url` approach that tried to read from `sidecar_config.json` files — evalhub doesn't write those files, so it always fell through to the localhost fallback.

A clear WARNING is logged when the URL remains a sidecar address in KFP mode, with guidance to set `kfp_config.model_url`.

### Backward compatibility

- Old evalhub (< 0.4.4): SA token file is present, `model.url` is the real endpoint → existing flow is unaffected.
- New evalhub (>= 0.4.4) + simple mode: `localhost:8080` works fine (sidecar is co-located).
- New evalhub + KFP + intents: model URL resolved from `intents_models` automatically.
- New evalhub + KFP + non-intents: requires `kfp_config.model_url` in the payload.

## Test plan

- [x] 299 unit tests pass (288 existing + 11 new)
- [x] New `TestResolveKfpModelUrl` test class covers the full resolution chain, precedence, edge cases, and warning behavior
- [ ] Manual cluster test: deploy with evalhub >= 0.4.4 + sidecar, run intents KFP benchmark without `kfp_config.model_url` — generator URI should resolve from `intents_models`
- [ ] Manual cluster test: verify old evalhub (SA token mounted) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)