### PR TITLE
fix: surface garak scan.log errors in CLI and KFP step logs

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/core/garak_runner.py
+++ b/src/llama_stack_provider_trustyai_garak/core/garak_runner.py
@@ -9,7 +9,7 @@ import signal
 import subprocess
 import threading
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 import re
 
@@ -17,6 +17,9 @@ logger = logging.getLogger(__name__)
 _STDERR_WARNING_PATTERN = re.compile(
     r"(?:\berror\b|\bexception\b|\btraceback\b|\bfailed\b|\bfatal\b|\bwarn(?:ing)?\b|⚠)",
     re.IGNORECASE,
+)
+_SCAN_LOG_ISSUE_PATTERN = re.compile(
+    r"^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2},\d+\s+(ERROR|WARNING)\s+(.+)$",
 )
 
 
@@ -29,6 +32,7 @@ class GarakScanResult:
     stderr: str
     report_prefix: Path
     timed_out: bool = False
+    log_errors: list[str] = field(default_factory=list)
 
     @property
     def success(self) -> bool:
@@ -64,6 +68,30 @@ class GarakScanResult:
             self.report_html,
         ]
         return [f for f in candidates if f.exists()]
+
+
+def _extract_scan_log_issues(log_file: Path) -> list[str]:
+    """Extract ERROR/WARNING lines from garak's scan.log and log them.
+
+    Garak writes its internal log to scan.log via GARAK_LOG_FILE but never
+    outputs these to stdout/stderr. This function surfaces them so they
+    appear in CLI and KFP step logs.
+    """
+    if not log_file.exists():
+        return []
+    issues: list[str] = []
+    try:
+        with open(log_file, encoding="utf-8", errors="replace") as f:
+            for line in f:
+                m = _SCAN_LOG_ISSUE_PATTERN.match(line.rstrip())
+                if m:
+                    level_str, message = m.group(1), m.group(2)
+                    log_level = logging.ERROR if level_str == "ERROR" else logging.WARNING
+                    logger.log(log_level, "garak[scan.log] %s", message)
+                    issues.append(line.rstrip())
+    except OSError as exc:
+        logger.warning("Could not read scan.log: %s", exc)
+    return issues
 
 
 def run_garak_scan(
@@ -225,12 +253,17 @@ def run_garak_scan(
     if timed_out and not stderr:
         stderr = "Scan timed out"
 
+    log_errors: list[str] = []
+    if log_file:
+        log_errors = _extract_scan_log_issues(log_file)
+
     return GarakScanResult(
         returncode=returncode,
         stdout=stdout,
         stderr=stderr,
         report_prefix=report_prefix,
         timed_out=timed_out,
+        log_errors=log_errors,
     )
 
 

--- a/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
+++ b/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
@@ -506,6 +506,11 @@ def setup_and_run_garak(
 
     if result.success:
         logger.info("Garak scan completed successfully (rc=%s)", result.returncode)
+        if result.log_errors:
+            logger.warning(
+                "Garak scan succeeded but scan.log contains %d error/warning entries",
+                len(result.log_errors),
+            )
         try:
             convert_to_avid_report(result.report_jsonl)
         except Exception as exc:
@@ -516,6 +521,8 @@ def setup_and_run_garak(
             f"timed_out={result.timed_out}): "
             f"{result.stderr[:500] if result.stderr else 'no stderr'}"
         )
+        if result.log_errors:
+            error_msg += "\nscan.log errors:\n" + "\n".join(result.log_errors)
         logger.error(error_msg)
         raise GarakError(error_msg)
 

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -181,6 +181,8 @@ class GarakAdapter(FrameworkAdapter):
                 error_msg = f"Garak scan failed: {result.stderr}" if result.stderr else "Unknown error"
                 if result.timed_out:
                     error_msg = f"Scan timed out after {timeout} seconds"
+                if result.log_errors:
+                    error_msg += "\nscan.log errors:\n" + "\n".join(result.log_errors)
 
                 callbacks.report_status(
                     JobStatusUpdate(

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -771,6 +771,18 @@ class TestExtractScanLogIssues:
         )
         assert _extract_scan_log_issues(log_file) == []
 
+    def test_unreadable_file_returns_empty(self, tmp_path, caplog):
+        import logging
+
+        log_file = tmp_path / "scan.log"
+        log_file.write_text("2026-03-26 14:23:05,309  ERROR  Some error\n")
+        log_file.chmod(0o000)
+        with caplog.at_level(logging.WARNING):
+            result = _extract_scan_log_issues(log_file)
+        assert result == []
+        assert "Could not read scan.log" in caplog.text
+        log_file.chmod(0o644)
+
 
 class TestGarakScanResultLogErrors:
     def test_default_is_empty_list(self):

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -9,6 +9,10 @@ from unittest.mock import MagicMock, Mock, patch
 import pandas as pd
 import pytest
 
+from llama_stack_provider_trustyai_garak.core.garak_runner import (
+    GarakScanResult,
+    _extract_scan_log_issues,
+)
 from llama_stack_provider_trustyai_garak.core.pipeline_steps import (
     log_kfp_metrics,
     normalize_prompts,
@@ -733,3 +737,90 @@ class TestLogKfpMetrics:
         }
         log_kfp_metrics(mock_metrics, result_dict, art_intents=True)
         mock_metrics.log_metric.assert_any_call("tbsa", 0.8)
+
+
+class TestExtractScanLogIssues:
+    def test_extracts_errors_and_warnings(self, tmp_path):
+        log_file = tmp_path / "scan.log"
+        log_file.write_text(
+            "2026-03-26 13:50:00,375  INFO  Applying probes.multilingual.TranslationIntent\n"
+            "2026-03-26 13:50:00,376  DEBUG  probe execute: <object at 0x7f>\n"
+            "2026-03-26 14:23:05,309  ERROR  Attack method failed: unable to allocate shared memory\n"
+            "2026-03-26 14:23:06,000  WARNING  Fallback behaviour activated\n"
+            "2026-03-26 14:23:07,000  INFO  probe init: <tap object>\n"
+        )
+        issues = _extract_scan_log_issues(log_file)
+        assert len(issues) == 2
+        assert "ERROR" in issues[0]
+        assert "Attack method failed" in issues[0]
+        assert "WARNING" in issues[1]
+        assert "Fallback" in issues[1]
+
+    def test_missing_file_returns_empty(self, tmp_path):
+        assert _extract_scan_log_issues(tmp_path / "nonexistent.log") == []
+
+    def test_empty_file_returns_empty(self, tmp_path):
+        log_file = tmp_path / "scan.log"
+        log_file.write_text("")
+        assert _extract_scan_log_issues(log_file) == []
+
+    def test_no_issues_returns_empty(self, tmp_path):
+        log_file = tmp_path / "scan.log"
+        log_file.write_text(
+            "2026-03-26 13:50:00,375  INFO  All good\n"
+            "2026-03-26 13:50:00,376  DEBUG  Verbose debug info\n"
+        )
+        assert _extract_scan_log_issues(log_file) == []
+
+
+class TestGarakScanResultLogErrors:
+    def test_default_is_empty_list(self):
+        result = GarakScanResult(returncode=0, stdout="", stderr="", report_prefix=Path("/tmp/scan"))
+        assert result.log_errors == []
+
+    def test_populated_via_constructor(self):
+        errors = ["2026-03-26 14:23:05,309  ERROR  Something broke"]
+        result = GarakScanResult(
+            returncode=0, stdout="", stderr="", report_prefix=Path("/tmp/scan"), log_errors=errors
+        )
+        assert result.log_errors == errors
+
+
+class TestSetupAndRunGarakLogErrors:
+    @patch("llama_stack_provider_trustyai_garak.core.garak_runner.convert_to_avid_report")
+    @patch("llama_stack_provider_trustyai_garak.core.garak_runner.run_garak_scan")
+    def test_success_with_log_errors_logs_warnings(self, mock_scan, mock_avid, caplog):
+        import logging
+
+        scan_dir = Path(tempfile.mkdtemp())
+        mock_result = GarakScanResult(
+            returncode=0,
+            stdout="ok",
+            stderr="",
+            report_prefix=scan_dir / "scan",
+            log_errors=["2026-03-26 14:23:05,309  ERROR  Attack method failed"],
+        )
+        mock_scan.return_value = mock_result
+        mock_avid.return_value = True
+
+        config = json.dumps({"plugins": {"probes": []}, "reporting": {}})
+        with caplog.at_level(logging.WARNING):
+            result = setup_and_run_garak(config, None, scan_dir, 300)
+        assert result.success
+        assert "1 error/warning entries" in caplog.text
+
+    @patch("llama_stack_provider_trustyai_garak.core.garak_runner.run_garak_scan")
+    def test_failure_includes_log_errors(self, mock_scan):
+        scan_dir = Path(tempfile.mkdtemp())
+        mock_result = GarakScanResult(
+            returncode=1,
+            stdout="",
+            stderr="error occurred",
+            report_prefix=scan_dir / "scan",
+            log_errors=["2026-03-26 14:23:05,309  ERROR  Attack method failed"],
+        )
+        mock_scan.return_value = mock_result
+
+        config = json.dumps({"plugins": {"probes": []}, "reporting": {}})
+        with pytest.raises(GarakError, match="scan.log errors"):
+            setup_and_run_garak(config, None, scan_dir, 300)

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -767,8 +767,7 @@ class TestExtractScanLogIssues:
     def test_no_issues_returns_empty(self, tmp_path):
         log_file = tmp_path / "scan.log"
         log_file.write_text(
-            "2026-03-26 13:50:00,375  INFO  All good\n"
-            "2026-03-26 13:50:00,376  DEBUG  Verbose debug info\n"
+            "2026-03-26 13:50:00,375  INFO  All good\n2026-03-26 13:50:00,376  DEBUG  Verbose debug info\n"
         )
         assert _extract_scan_log_issues(log_file) == []
 
@@ -780,9 +779,7 @@ class TestGarakScanResultLogErrors:
 
     def test_populated_via_constructor(self):
         errors = ["2026-03-26 14:23:05,309  ERROR  Something broke"]
-        result = GarakScanResult(
-            returncode=0, stdout="", stderr="", report_prefix=Path("/tmp/scan"), log_errors=errors
-        )
+        result = GarakScanResult(returncode=0, stdout="", stderr="", report_prefix=Path("/tmp/scan"), log_errors=errors)
         assert result.log_errors == errors
 
 


### PR DESCRIPTION
## Summary

- After the garak subprocess finishes, parse `scan.log` for ERROR/WARNING lines and log them to the adapter's Python logger so they appear in CLI output and KFP step logs (ODH web UI)
- Add `log_errors` field to `GarakScanResult` so callers can include scan.log errors in status/error callback messages
- Surface warnings even when the scan "succeeds" (rc=0) — garak catches probe exceptions internally and continues, so errors can be silent

Ref: [RHOAIENG-55756](https://redhat.atlassian.net/browse/RHOAIENG-55756)

## Test plan

- [x] New `TestExtractScanLogIssues` tests: mixed levels, missing file, empty file, no issues
- [x] New `TestGarakScanResultLogErrors` tests: default empty list, populated via constructor
- [x] New `TestSetupAndRunGarakLogErrors` tests: success with log_errors logs warnings, failure includes log_errors in GarakError
- [x] All existing tests pass (296 passed)
- [x] ruff lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Surface garak scan.log ERROR/WARNING entries in scan results and pipeline logging so they are visible in CLI and KFP logs.

New Features:
- Capture ERROR/WARNING lines from garak scan.log into a new log_errors field on GarakScanResult.
- Propagate scan.log errors into pipeline error messages and evalhub adapter status callbacks for failed scans.

Enhancements:
- Log scan.log ERROR/WARNING entries to the Python logger when scans succeed, including a count of issues in pipeline logs.

Tests:
- Add unit tests for extracting scan.log issues, default and populated log_errors on GarakScanResult, and handling of log_errors in setup_and_run_garak success and failure cases.