### PR TITLE
feat: expose hitlog.jsonl in S3 artifact metadata and MLflow

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -271,6 +271,7 @@ class GarakAdapter(FrameworkAdapter):
                 artifact_keys: dict[str, str] = {
                     "scan_report": f"{s3_prefix}/scan.report.jsonl",
                     "scan_html_report": f"{s3_prefix}/scan.report.html",
+                    "scan_hitlog": f"{s3_prefix}/scan.hitlog.jsonl",
                 }
                 if art_intents:
                     artifact_keys["sdg_raw_output"] = f"{s3_prefix}/sdg_raw_output.csv"
@@ -328,6 +329,14 @@ class GarakAdapter(FrameworkAdapter):
                         MlflowArtifact(
                             "scan.report.jsonl",
                             result.report_jsonl.read_bytes(),
+                            "application/jsonl",
+                        )
+                    )
+                if result.hitlog_jsonl.exists():
+                    mlflow_artifacts.append(
+                        MlflowArtifact(
+                            "scan.hitlog.jsonl",
+                            result.hitlog_jsonl.read_bytes(),
                             "application/jsonl",
                         )
                     )

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -3437,6 +3437,7 @@ class TestArtifactMetadataSurfacing:
             "sdg_normalized_output": f"{s3_prefix}/sdg_normalized_output.csv",
             "intents_html_report": f"{s3_prefix}/scan.intents.html",
             "scan_report": f"{s3_prefix}/scan.report.jsonl",
+            "scan_hitlog": f"{s3_prefix}/scan.hitlog.jsonl",
         }
         verified = {}
         if _bucket:
@@ -3453,6 +3454,7 @@ class TestArtifactMetadataSurfacing:
         assert "sdg_normalized_output" in verified
         assert "scan_report" in verified
         assert "intents_html_report" not in verified
+        assert "scan_hitlog" not in verified
         assert verified["sdg_raw_output"] == f"s3://{bucket}/{s3_prefix}/sdg_raw_output.csv"
 
     def test_intents_kfp_job_bucket_from_kfp_config(self, monkeypatch):


### PR DESCRIPTION
With https://github.com/trustyai-explainability/garak/pull/10 , now we can expose hitlog.jsonl to the users!

## Summary
- Add `scan.hitlog.jsonl` to `evaluation_metadata.artifacts` so it is surfaced alongside `scan.report.jsonl` and `scan.report.html` in KFP mode (both intents and non-intents scans)
- Add `scan.hitlog.jsonl` to MLflow artifact uploads so it is available in experiment tracking for all execution modes
- Update artifact metadata test to cover the new key

## Test plan
- [x] All 308 existing tests pass
- [x] `TestArtifactMetadataSurfacing` updated and passing — verifies `scan_hitlog` is included in `artifact_keys` and correctly excluded when not present in S3
- [x] MLflow tests passing — confirms no regressions in artifact upload logic
- [x] Pre-commit hooks (ruff, ruff-format, mypy) all pass


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Expose scan hitlog artifacts in benchmark results and tracking integrations.

New Features:
- Surface scan.hitlog.jsonl as an S3 artifact alongside existing scan reports in KFP benchmark runs.
- Upload scan.hitlog.jsonl as an MLflow artifact when the hitlog file is present.

Tests:
- Extend artifact metadata tests to cover the new scan_hitlog key and its conditional surfacing behavior.