### PR TITLE
fix: cascading S3 credential resolution for evalhub sidecar model

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -989,7 +989,11 @@ class GarakAdapter(FrameworkAdapter):
                 configuration = k8s_client.Configuration()
                 configuration.host = f"https://{k8s_host}:{k8s_port}"
                 configuration.api_key = {"authorization": f"Bearer {auth_token}"}
-                configuration.verify_ssl = False
+                ca_cert = os.getenv("SSL_CA_CERT", "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+                if os.path.isfile(ca_cert):
+                    configuration.ssl_ca_cert = ca_cert
+                else:
+                    configuration.verify_ssl = False
                 k8s_client.Configuration.set_default(configuration)
                 v1 = k8s_client.CoreV1Api()
                 secret = v1.read_namespaced_secret(secret_name, namespace)

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -929,78 +929,179 @@ class GarakAdapter(FrameworkAdapter):
         cluster or missing RBAC), returning an empty dict so env-var fallback
         in ``create_s3_client`` still applies.
 
-        .. note:: **RBAC requirement** — The Job pod's service account must
-           have ``get`` permission on Secrets in the target namespace.
-           Example Role/RoleBinding::
+        Resolution chain (first success wins):
 
-               apiVersion: rbac.authorization.k8s.io/v1
-               kind: Role
-               metadata:
-                 name: secret-reader
-                 namespace: <namespace>
-               rules:
-               - apiGroups: [""]
-                 resources: ["secrets"]
-                 verbs: ["get"]
-               ---
-               apiVersion: rbac.authorization.k8s.io/v1
-               kind: RoleBinding
-               metadata:
-                 name: evalhub-secret-reader
-                 namespace: <namespace>
-               subjects:
-               - kind: ServiceAccount
-                 name: <job-service-account>
-                 namespace: <namespace>
-               roleRef:
-                 kind: Role
-                 name: secret-reader
-                 apiGroup: rbac.authorization.k8s.io
-
-           Without this, the call returns an empty dict and S3 operations
-           fall back to environment variables (which may also be empty,
-           causing job failures).
+        1. **Direct K8s API** (``load_incluster_config``) — works on
+           pre-sidecar evalhub where the SA token is auto-mounted.
+        2. **``KFP_AUTH_TOKEN`` + ``KUBERNETES_SERVICE_HOST``** env vars —
+           fallback when SA token file is absent but env vars are set.
+        3. **Sidecar proxy** (``k8s_sa_token:ref``) — evalhub >= 0.4.4
+           sidecar model.  Reads the secret via the K8s API through the
+           sidecar at ``localhost:8080``, which resolves the ref token and
+           injects the pod SA token.  Requires ``k8s_sa_token`` and
+           ``k8s_url`` keys in the model auth secret.
+        4. **Model auth secret** (``read_model_auth_key``) — last resort
+           if the user placed S3 credentials directly in the model auth
+           secret (keys: ``s3_access_key``, ``s3_secret_key``,
+           ``s3_endpoint``, ``s3_bucket``, ``s3_region``).
+        5. **``load_kube_config``** — local development only.
         """
         import base64
 
+        _S3_KEYS = {
+            "access_key": "AWS_ACCESS_KEY_ID",
+            "secret_key": "AWS_SECRET_ACCESS_KEY",
+            "region": "AWS_DEFAULT_REGION",
+            "bucket": "AWS_S3_BUCKET",
+            "endpoint_url": "AWS_S3_ENDPOINT",
+        }
+
+        def _extract_from_secret_data(data: dict) -> dict:
+            def _decode(key: str) -> str:
+                val = data.get(key, "")
+                return base64.b64decode(val).decode() if val else ""
+
+            return {field: _decode(secret_key) for field, secret_key in _S3_KEYS.items()}
+
+        # --- Step 1: Direct K8s API (pre-sidecar evalhub) ---
         try:
             from kubernetes import client as k8s_client, config as k8s_config
 
             try:
                 k8s_config.load_incluster_config()
+                v1 = k8s_client.CoreV1Api()
+                secret = v1.read_namespaced_secret(secret_name, namespace)
+                logger.info("Read S3 credentials from secret %s/%s via in-cluster config", namespace, secret_name)
+                return _extract_from_secret_data(secret.data or {})
             except k8s_config.ConfigException:
-                # evalhub PR #672: SA token is no longer auto-mounted on the adapter
-                # pod. Try authenticating via KFP_AUTH_TOKEN (already required for
-                # KFP client auth), then fall back to kubeconfig for local dev.
-                auth_token = os.getenv("KFP_AUTH_TOKEN", "")
-                k8s_host = os.getenv("KUBERNETES_SERVICE_HOST", "")
-                k8s_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
-                if auth_token and k8s_host:
-                    configuration = k8s_client.Configuration()
-                    configuration.host = f"https://{k8s_host}:{k8s_port}"
-                    configuration.api_key = {"authorization": f"Bearer {auth_token}"}
-                    configuration.verify_ssl = False
-                    k8s_client.Configuration.set_default(configuration)
-                else:
-                    k8s_config.load_kube_config()
+                logger.debug("load_incluster_config failed, trying fallbacks")
+        except Exception as exc:
+            logger.debug("K8s client import or in-cluster config failed: %s", exc)
+
+        # --- Step 2: KFP_AUTH_TOKEN + KUBERNETES_SERVICE_HOST env vars ---
+        auth_token = os.getenv("KFP_AUTH_TOKEN", "")
+        k8s_host = os.getenv("KUBERNETES_SERVICE_HOST", "")
+        k8s_port = os.getenv("KUBERNETES_SERVICE_PORT", "443")
+        if auth_token and k8s_host:
+            try:
+                from kubernetes import client as k8s_client
+
+                configuration = k8s_client.Configuration()
+                configuration.host = f"https://{k8s_host}:{k8s_port}"
+                configuration.api_key = {"authorization": f"Bearer {auth_token}"}
+                configuration.verify_ssl = False
+                k8s_client.Configuration.set_default(configuration)
+                v1 = k8s_client.CoreV1Api()
+                secret = v1.read_namespaced_secret(secret_name, namespace)
+                logger.info("Read S3 credentials from secret %s/%s via KFP_AUTH_TOKEN", namespace, secret_name)
+                return _extract_from_secret_data(secret.data or {})
+            except Exception as exc:
+                logger.debug("KFP_AUTH_TOKEN K8s API call failed: %s", exc)
+
+        # --- Step 3: Sidecar proxy with k8s_sa_token:ref (evalhub >= 0.4.4) ---
+        try:
+            result = GarakAdapter._read_secret_via_sidecar(secret_name, namespace)
+            if result:
+                logger.info("Read S3 credentials from secret %s/%s via sidecar proxy", namespace, secret_name)
+                return _extract_from_secret_data(result)
+        except Exception as exc:
+            logger.debug("Sidecar proxy K8s API call failed: %s", exc)
+
+        # --- Step 4: read_model_auth_key for S3 keys in model auth secret ---
+        try:
+            model_auth_creds = GarakAdapter._read_s3_from_model_auth()
+            if any(model_auth_creds.values()):
+                logger.info("Read S3 credentials from model auth secret")
+                return model_auth_creds
+        except Exception as exc:
+            logger.debug("read_model_auth_key for S3 failed: %s", exc)
+
+        # --- Step 5: load_kube_config (local dev) ---
+        try:
+            from kubernetes import client as k8s_client, config as k8s_config
+
+            k8s_config.load_kube_config()
             v1 = k8s_client.CoreV1Api()
             secret = v1.read_namespaced_secret(secret_name, namespace)
-            data = secret.data or {}
-
-            def _decode(key: str) -> str:
-                val = data.get(key, "")
-                return base64.b64decode(val).decode() if val else ""
-
-            return {
-                "access_key": _decode("AWS_ACCESS_KEY_ID"),
-                "secret_key": _decode("AWS_SECRET_ACCESS_KEY"),
-                "region": _decode("AWS_DEFAULT_REGION"),
-                "bucket": _decode("AWS_S3_BUCKET"),
-                "endpoint_url": _decode("AWS_S3_ENDPOINT"),
-            }
+            logger.info("Read S3 credentials from secret %s/%s via kubeconfig", namespace, secret_name)
+            return _extract_from_secret_data(secret.data or {})
         except Exception as exc:
             logger.warning("Could not read S3 credentials from secret %s/%s: %s", namespace, secret_name, exc)
             return {}
+
+    @staticmethod
+    def _read_secret_via_sidecar(secret_name: str, namespace: str) -> dict | None:
+        """Read a K8s secret via the evalhub sidecar proxy.
+
+        Uses the ``k8s_sa_token:ref`` / ``k8s_url`` convention from evalhub
+        PR #681.  The sidecar resolves the ref token (injecting the pod SA
+        token when the secret value is empty) and routes the request to the
+        K8s API server specified by ``k8s_url``.
+
+        Returns the secret's ``.data`` dict (base64-encoded values) on
+        success, or None if the sidecar proxy is not configured.
+        """
+        try:
+            from evalhub.adapter.auth import read_model_auth_key
+        except ImportError:
+            return None
+
+        k8s_url = (read_model_auth_key("k8s_url") or "").strip()
+        if not k8s_url:
+            return None
+
+        import urllib.request
+        import ssl
+
+        token_header = "Bearer k8s_sa_token:ref"
+        api_path = f"/api/v1/namespaces/{namespace}/secrets/{secret_name}"
+        sidecar_url = f"http://localhost:8080{api_path}"
+
+        ctx = ssl.create_default_context()
+        ctx.check_hostname = False
+        ctx.verify_mode = ssl.CERT_NONE
+
+        req = urllib.request.Request(
+            sidecar_url,
+            headers={
+                "Authorization": token_header,
+                "Accept": "application/json",
+            },
+        )
+        with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+            body = json.loads(resp.read().decode())
+            return body.get("data", {})
+
+    @staticmethod
+    def _read_s3_from_model_auth() -> dict:
+        """Read S3 credentials from the model auth secret.
+
+        Uses ``read_model_auth_key`` to read S3 credential keys that the
+        user may have placed directly in the model auth secret.  This is
+        a last-resort fallback when the adapter cannot read the Data
+        Connection secret via the K8s API.
+        """
+        try:
+            from evalhub.adapter.auth import read_model_auth_key
+        except ImportError:
+            return {}
+
+        _MODEL_AUTH_S3_KEYS: list[tuple[str, list[str]]] = [
+            ("access_key", ["AWS_ACCESS_KEY_ID", "aws_access_key_id", "s3_access_key"]),
+            ("secret_key", ["AWS_SECRET_ACCESS_KEY", "aws_secret_access_key", "s3_secret_key"]),
+            ("region", ["AWS_DEFAULT_REGION", "aws_default_region", "s3_region"]),
+            ("bucket", ["AWS_S3_BUCKET", "aws_s3_bucket", "s3_bucket"]),
+            ("endpoint_url", ["AWS_S3_ENDPOINT", "aws_s3_endpoint", "s3_endpoint"]),
+        ]
+        result: dict[str, str] = {}
+        for field, candidates in _MODEL_AUTH_S3_KEYS:
+            val = ""
+            for key in candidates:
+                val = (read_model_auth_key(key) or "").strip()
+                if val:
+                    break
+            result[field] = val
+        return result
 
     @staticmethod
     def _resolve_s3_credentials(kfp_config: "KFPConfig", secret_creds: dict) -> dict:
@@ -1045,8 +1146,15 @@ class GarakAdapter(FrameworkAdapter):
 
             resolved[field] = cfg_val or secret_val or env_val or None
 
-        for field in ("access_key", "secret_key", "region"):
-            resolved[field] = (secret_creds.get(field, "") or "").strip() or None
+        _CRED_ENV_MAP = {
+            "access_key": "AWS_ACCESS_KEY_ID",
+            "secret_key": "AWS_SECRET_ACCESS_KEY",
+            "region": "AWS_DEFAULT_REGION",
+        }
+        for field, env_var in _CRED_ENV_MAP.items():
+            secret_val = (secret_creds.get(field, "") or "").strip()
+            env_val = (os.getenv(env_var, "") or "").strip()
+            resolved[field] = secret_val or env_val or None
 
         return resolved
 

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -1055,15 +1055,10 @@ class GarakAdapter(FrameworkAdapter):
             return None
 
         import urllib.request
-        import ssl
 
         token_header = "Bearer k8s_sa_token:ref"
         api_path = f"/api/v1/namespaces/{namespace}/secrets/{secret_name}"
         sidecar_url = f"http://localhost:8080{api_path}"
-
-        ctx = ssl.create_default_context()
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
 
         req = urllib.request.Request(
             sidecar_url,
@@ -1072,7 +1067,7 @@ class GarakAdapter(FrameworkAdapter):
                 "Accept": "application/json",
             },
         )
-        with urllib.request.urlopen(req, timeout=10, context=ctx) as resp:
+        with urllib.request.urlopen(req, timeout=10) as resp:
             body = json.loads(resp.read().decode())
             return body.get("data", {})
 
@@ -1116,10 +1111,11 @@ class GarakAdapter(FrameworkAdapter):
           2. K8s secret (read via _read_s3_credentials_from_secret)
           3. Environment variable (``AWS_S3_BUCKET`` / ``AWS_S3_ENDPOINT``)
 
-        For ``access_key``, ``secret_key``, and ``region``, values come
-        only from the K8s secret.  These fields have no kfp_config
-        equivalent; when the secret is empty, ``create_s3_client``
-        applies its own env-var fallback (``AWS_ACCESS_KEY_ID``, etc.).
+        For ``access_key``, ``secret_key``, and ``region``, the first
+        non-empty value wins:
+          1. K8s secret (read via _read_s3_credentials_from_secret)
+          2. Environment variable (``AWS_ACCESS_KEY_ID`` /
+             ``AWS_SECRET_ACCESS_KEY`` / ``AWS_DEFAULT_REGION``)
 
         When both kfp_config and the secret provide different non-empty
         values for the same field, the kfp_config value is used and a

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -866,11 +866,509 @@ class TestResolveS3Credentials:
         module = _load_evalhub_garak_adapter(monkeypatch)
         monkeypatch.delenv("AWS_S3_BUCKET", raising=False)
         monkeypatch.delenv("AWS_S3_ENDPOINT", raising=False)
+        monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+        monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("AWS_DEFAULT_REGION", raising=False)
         kfp_cfg = self._make_kfp_config()
         resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, {})
         assert resolved["bucket"] is None
         assert resolved["endpoint_url"] is None
         assert resolved["access_key"] is None
+
+    def test_access_key_falls_back_to_env(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-ak")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-sk")
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "env-region")
+        kfp_cfg = self._make_kfp_config()
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, {})
+        assert resolved["access_key"] == "env-ak"
+        assert resolved["secret_key"] == "env-sk"
+        assert resolved["region"] == "env-region"
+
+    def test_secret_creds_take_precedence_over_env_for_access_key(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-ak")
+        monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-sk")
+        secret = {"access_key": "secret-ak", "secret_key": "secret-sk", "region": ""}
+        kfp_cfg = self._make_kfp_config()
+        resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
+        assert resolved["access_key"] == "secret-ak"
+        assert resolved["secret_key"] == "secret-sk"
+
+
+class TestReadS3CredentialsCascade:
+    """Tests for the cascading fallback chain in _read_s3_credentials_from_secret."""
+
+    def test_step1_incluster_config_success(self, monkeypatch):
+        """Step 1: Direct K8s API via load_incluster_config succeeds."""
+        import base64
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        fake_secret_data = {
+            "AWS_ACCESS_KEY_ID": base64.b64encode(b"ak-incluster").decode(),
+            "AWS_SECRET_ACCESS_KEY": base64.b64encode(b"sk-incluster").decode(),
+            "AWS_DEFAULT_REGION": base64.b64encode(b"us-east-1").decode(),
+            "AWS_S3_BUCKET": base64.b64encode(b"bucket-incluster").decode(),
+            "AWS_S3_ENDPOINT": base64.b64encode(b"http://s3:9000").decode(),
+        }
+
+        class FakeV1:
+            def read_namespaced_secret(self, name, ns):
+                return SimpleNamespace(data=fake_secret_data)
+
+        k8s_config = types.ModuleType("kubernetes.config")
+        k8s_config.load_incluster_config = lambda: None
+        k8s_config.ConfigException = type("ConfigException", (Exception,), {})
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_client.CoreV1Api = FakeV1
+        k8s_client.Configuration = type(
+            "Configuration",
+            (),
+            {
+                "host": "",
+                "api_key": {},
+                "verify_ssl": True,
+                "set_default": classmethod(lambda cls, c: None),
+            },
+        )
+
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result["access_key"] == "ak-incluster"
+        assert result["bucket"] == "bucket-incluster"
+
+    def test_step2_kfp_auth_token_fallback(self, monkeypatch):
+        """Step 2: KFP_AUTH_TOKEN + KUBERNETES_SERVICE_HOST env vars."""
+        import base64
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        monkeypatch.setenv("KFP_AUTH_TOKEN", "fake-token")
+        monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+        monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+
+        fake_data = {
+            "AWS_ACCESS_KEY_ID": base64.b64encode(b"ak-token").decode(),
+            "AWS_SECRET_ACCESS_KEY": base64.b64encode(b"sk-token").decode(),
+            "AWS_DEFAULT_REGION": "",
+            "AWS_S3_BUCKET": base64.b64encode(b"bucket-token").decode(),
+            "AWS_S3_ENDPOINT": base64.b64encode(b"http://s3:9000").decode(),
+        }
+
+        _incluster_called = {"v": False}
+
+        class FakeV1:
+            def read_namespaced_secret(self, name, ns):
+                return SimpleNamespace(data=fake_data)
+
+        class FakeConfigException(Exception):
+            pass
+
+        k8s_config = types.ModuleType("kubernetes.config")
+
+        def _fail_incluster():
+            raise FakeConfigException("no SA token")
+
+        k8s_config.load_incluster_config = _fail_incluster
+        k8s_config.ConfigException = FakeConfigException
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_client.CoreV1Api = FakeV1
+        k8s_client.Configuration = type(
+            "Configuration",
+            (),
+            {
+                "host": "",
+                "api_key": {},
+                "verify_ssl": True,
+                "set_default": classmethod(lambda cls, c: None),
+            },
+        )
+
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result["access_key"] == "ak-token"
+        assert result["bucket"] == "bucket-token"
+
+    def test_step3_sidecar_proxy_fallback(self, monkeypatch):
+        """Step 3: Sidecar proxy with k8s_sa_token:ref."""
+        import base64
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        monkeypatch.delenv("KFP_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        class FakeConfigException(Exception):
+            pass
+
+        k8s_config = types.ModuleType("kubernetes.config")
+        k8s_config.load_incluster_config = lambda: (_ for _ in ()).throw(FakeConfigException("no"))
+        k8s_config.ConfigException = FakeConfigException
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        sidecar_data = {
+            "AWS_ACCESS_KEY_ID": base64.b64encode(b"ak-sidecar").decode(),
+            "AWS_SECRET_ACCESS_KEY": base64.b64encode(b"sk-sidecar").decode(),
+            "AWS_DEFAULT_REGION": base64.b64encode(b"eu-west-1").decode(),
+            "AWS_S3_BUCKET": base64.b64encode(b"sidecar-bucket").decode(),
+            "AWS_S3_ENDPOINT": base64.b64encode(b"http://s3-sidecar:9000").decode(),
+        }
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_secret_via_sidecar",
+            staticmethod(lambda name, ns: sidecar_data),
+        )
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result["access_key"] == "ak-sidecar"
+        assert result["bucket"] == "sidecar-bucket"
+        assert result["endpoint_url"] == "http://s3-sidecar:9000"
+
+    def test_step4_model_auth_fallback(self, monkeypatch):
+        """Step 4: read_model_auth_key for S3 keys."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        monkeypatch.delenv("KFP_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        class FakeConfigException(Exception):
+            pass
+
+        k8s_config = types.ModuleType("kubernetes.config")
+        k8s_config.load_incluster_config = lambda: (_ for _ in ()).throw(FakeConfigException("no"))
+        k8s_config.ConfigException = FakeConfigException
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_secret_via_sidecar",
+            staticmethod(lambda name, ns: None),
+        )
+
+        model_auth_data = {
+            "access_key": "ak-model-auth",
+            "secret_key": "sk-model-auth",
+            "region": "ap-south-1",
+            "bucket": "model-auth-bucket",
+            "endpoint_url": "http://s3-model:9000",
+        }
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_s3_from_model_auth",
+            staticmethod(lambda: model_auth_data),
+        )
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result["access_key"] == "ak-model-auth"
+        assert result["bucket"] == "model-auth-bucket"
+        assert result["region"] == "ap-south-1"
+
+    def test_step5_kubeconfig_fallback(self, monkeypatch):
+        """Step 5: load_kube_config for local dev."""
+        import base64
+
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        monkeypatch.delenv("KFP_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        fake_data = {
+            "AWS_ACCESS_KEY_ID": base64.b64encode(b"ak-kubeconfig").decode(),
+            "AWS_SECRET_ACCESS_KEY": base64.b64encode(b"sk-kubeconfig").decode(),
+            "AWS_DEFAULT_REGION": "",
+            "AWS_S3_BUCKET": base64.b64encode(b"kube-bucket").decode(),
+            "AWS_S3_ENDPOINT": base64.b64encode(b"http://s3-local:9000").decode(),
+        }
+
+        class FakeConfigException(Exception):
+            pass
+
+        class FakeV1:
+            def read_namespaced_secret(self, name, ns):
+                return SimpleNamespace(data=fake_data)
+
+        k8s_config = types.ModuleType("kubernetes.config")
+        k8s_config.load_incluster_config = lambda: (_ for _ in ()).throw(FakeConfigException("no"))
+        k8s_config.load_kube_config = lambda: None
+        k8s_config.ConfigException = FakeConfigException
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_client.CoreV1Api = FakeV1
+        k8s_client.Configuration = type(
+            "Configuration",
+            (),
+            {
+                "host": "",
+                "api_key": {},
+                "verify_ssl": True,
+                "set_default": classmethod(lambda cls, c: None),
+            },
+        )
+
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_secret_via_sidecar",
+            staticmethod(lambda name, ns: None),
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_s3_from_model_auth",
+            staticmethod(lambda: {}),
+        )
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result["access_key"] == "ak-kubeconfig"
+        assert result["bucket"] == "kube-bucket"
+
+    def test_all_fallbacks_fail_returns_empty(self, monkeypatch):
+        """All steps fail — returns empty dict."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        monkeypatch.delenv("KFP_AUTH_TOKEN", raising=False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        class FakeConfigException(Exception):
+            pass
+
+        k8s_config = types.ModuleType("kubernetes.config")
+        k8s_config.load_incluster_config = lambda: (_ for _ in ()).throw(FakeConfigException("no"))
+        k8s_config.load_kube_config = lambda: (_ for _ in ()).throw(Exception("no kubeconfig"))
+        k8s_config.ConfigException = FakeConfigException
+
+        k8s_client = types.ModuleType("kubernetes.client")
+        k8s_client.CoreV1Api = lambda: None
+        k8s_client.Configuration = type(
+            "Configuration",
+            (),
+            {
+                "host": "",
+                "api_key": {},
+                "verify_ssl": True,
+                "set_default": classmethod(lambda cls, c: None),
+            },
+        )
+
+        k8s_module = types.ModuleType("kubernetes")
+        k8s_module.client = k8s_client
+        k8s_module.config = k8s_config
+
+        monkeypatch.setitem(sys.modules, "kubernetes", k8s_module)
+        monkeypatch.setitem(sys.modules, "kubernetes.client", k8s_client)
+        monkeypatch.setitem(sys.modules, "kubernetes.config", k8s_config)
+
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_secret_via_sidecar",
+            staticmethod(lambda name, ns: None),
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_read_s3_from_model_auth",
+            staticmethod(lambda: {}),
+        )
+
+        result = module.GarakAdapter._read_s3_credentials_from_secret("my-secret", "ns")
+        assert result == {}
+
+
+class TestReadSecretViaSidecar:
+    """Tests for _read_secret_via_sidecar."""
+
+    def test_returns_none_when_k8s_url_not_set(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda _name: None
+
+        result = module.GarakAdapter._read_secret_via_sidecar("secret", "ns")
+        assert result is None
+
+    def test_calls_sidecar_with_correct_url_and_headers(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        auth_keys = {
+            "k8s_url": "https://api.cluster.local:6443",
+            "k8s_sa_token": "",
+        }
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: auth_keys.get(name)
+
+        import base64
+
+        secret_payload = {
+            "data": {
+                "AWS_ACCESS_KEY_ID": base64.b64encode(b"ak").decode(),
+                "AWS_S3_BUCKET": base64.b64encode(b"bkt").decode(),
+            }
+        }
+
+        captured = {}
+
+        class FakeResponse:
+            def read(self):
+                return json.dumps(secret_payload).encode()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                pass
+
+        original_urlopen = None
+
+        def fake_urlopen(req, timeout=None, context=None):
+            captured["url"] = req.full_url
+            captured["auth"] = req.get_header("Authorization")
+            return FakeResponse()
+
+        import urllib.request
+
+        monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+        result = module.GarakAdapter._read_secret_via_sidecar("my-s3-secret", "evalhub-tenant")
+        assert result["AWS_ACCESS_KEY_ID"] == base64.b64encode(b"ak").decode()
+        assert captured["url"] == "http://localhost:8080/api/v1/namespaces/evalhub-tenant/secrets/my-s3-secret"
+        assert captured["auth"] == "Bearer k8s_sa_token:ref"
+
+
+class TestReadS3FromModelAuth:
+    """Tests for _read_s3_from_model_auth."""
+
+    def test_reads_standard_aws_keys_uppercase(self, monkeypatch):
+        """Standard AWS_* uppercase keys (most common format)."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        model_auth_keys = {
+            "AWS_ACCESS_KEY_ID": "ma-ak",
+            "AWS_SECRET_ACCESS_KEY": "ma-sk",
+            "AWS_DEFAULT_REGION": "us-west-2",
+            "AWS_S3_BUCKET": "ma-bucket",
+            "AWS_S3_ENDPOINT": "http://s3-ma:9000",
+        }
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: model_auth_keys.get(name)
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result["access_key"] == "ma-ak"
+        assert result["secret_key"] == "ma-sk"
+        assert result["region"] == "us-west-2"
+        assert result["bucket"] == "ma-bucket"
+        assert result["endpoint_url"] == "http://s3-ma:9000"
+
+    def test_reads_standard_aws_keys_lowercase(self, monkeypatch):
+        """Lowercase aws_* keys also work."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        model_auth_keys = {
+            "aws_access_key_id": "ma-ak-lower",
+            "aws_secret_access_key": "ma-sk-lower",
+            "aws_default_region": "eu-west-1",
+            "aws_s3_bucket": "lower-bucket",
+            "aws_s3_endpoint": "http://s3-lower:9000",
+        }
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: model_auth_keys.get(name)
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result["access_key"] == "ma-ak-lower"
+        assert result["secret_key"] == "ma-sk-lower"
+        assert result["region"] == "eu-west-1"
+        assert result["bucket"] == "lower-bucket"
+        assert result["endpoint_url"] == "http://s3-lower:9000"
+
+    def test_reads_custom_s3_prefix_keys(self, monkeypatch):
+        """Custom s3_* keys as fallback."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        model_auth_keys = {
+            "s3_access_key": "ma-ak-custom",
+            "s3_secret_key": "ma-sk-custom",
+            "s3_region": "ap-south-1",
+            "s3_bucket": "custom-bucket",
+            "s3_endpoint": "http://s3-custom:9000",
+        }
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: model_auth_keys.get(name)
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result["access_key"] == "ma-ak-custom"
+        assert result["secret_key"] == "ma-sk-custom"
+        assert result["region"] == "ap-south-1"
+        assert result["bucket"] == "custom-bucket"
+        assert result["endpoint_url"] == "http://s3-custom:9000"
+
+    def test_uppercase_takes_precedence_over_lowercase(self, monkeypatch):
+        """AWS_ACCESS_KEY_ID wins over aws_access_key_id."""
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        model_auth_keys = {
+            "AWS_ACCESS_KEY_ID": "upper-ak",
+            "aws_access_key_id": "lower-ak",
+            "s3_access_key": "custom-ak",
+        }
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: model_auth_keys.get(name)
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result["access_key"] == "upper-ak"
+
+    def test_returns_empty_when_no_keys_set(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda _name: None
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result["access_key"] == ""
+        assert result["bucket"] == ""
+
+    def test_returns_empty_dict_when_evalhub_not_importable(self, monkeypatch):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        monkeypatch.delitem(sys.modules, "evalhub.adapter.auth", raising=False)
+
+        result = module.GarakAdapter._read_s3_from_model_auth()
+        assert result == {}
 
 
 class TestPollKFPRun:

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -890,11 +890,17 @@ class TestResolveS3Credentials:
         module = _load_evalhub_garak_adapter(monkeypatch)
         monkeypatch.setenv("AWS_ACCESS_KEY_ID", "env-ak")
         monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "env-sk")
-        secret = {"access_key": "secret-ak", "secret_key": "secret-sk", "region": ""}
+        monkeypatch.setenv("AWS_DEFAULT_REGION", "env-region")
+        secret = {
+            "access_key": "secret-ak",
+            "secret_key": "secret-sk",
+            "region": "secret-region",
+        }
         kfp_cfg = self._make_kfp_config()
         resolved = module.GarakAdapter._resolve_s3_credentials(kfp_cfg, secret)
         assert resolved["access_key"] == "secret-ak"
         assert resolved["secret_key"] == "secret-sk"
+        assert resolved["region"] == "secret-region"
 
 
 class TestReadS3CredentialsCascade:


### PR DESCRIPTION
## Problem

In KFP mode, after the KFP pipeline run succeeds, the adapter pod downloads scan results from S3 using AWS credentials read from the Data Connection K8s secret (`ds-pipeline-s3-dspa`). This requires calling the K8s API.

In evalhub >= 0.4.4 (sidecar proxy model), the adapter pod runs with `AutomountServiceAccountToken=false` — no SA token file, no `KFP_AUTH_TOKEN`, no `KUBERNETES_SERVICE_HOST`. All existing K8s API fallback paths fail, producing:

```
WARNING - Could not read S3 credentials from secret evalhub-tenant/ds-pipeline-s3-dspa: Invalid kube-config file. No configuration found.
WARNING - No S3 bucket configured; skipping result download
```

**The KFP run succeeds but all results are lost** because the adapter cannot read S3 credentials to download them.

## Fix

Replaces the single-path S3 secret reader with a **five-step cascading fallback chain** (first success wins):

| Step | Method | When it works |
|------|--------|---------------|
| 1 | `load_incluster_config()` | Pre-sidecar evalhub (SA token auto-mounted) |
| 2 | `KFP_AUTH_TOKEN` + `KUBERNETES_SERVICE_HOST` env vars | Legacy env-var auth |
| 3 | **Sidecar proxy with `k8s_sa_token:ref`** (NEW) | evalhub >= 0.4.4 with ref-token mechanism (eval-hub PR #681) |
| 4 | **Model auth secret S3 keys** (NEW) | Direct S3 creds in model auth secret (`AWS_ACCESS_KEY_ID`, `aws_access_key_id`, `s3_access_key` etc.) |
| 5 | `load_kube_config()` | Local dev |

Also adds env-var fallback for `access_key`/`secret_key`/`region` in `_resolve_s3_credentials` (previously only sourced from K8s secret).

### Step 3: Sidecar proxy path

Uses the eval-hub PR #681 ref-token mechanism — the adapter sends `Authorization: Bearer k8s_sa_token:ref` to `localhost:8080`, the sidecar resolves the ref token (injecting the pod SA token when the secret value is empty), and routes the request to the K8s API URL specified by `k8s_url`.

### Step 4: Model auth secret S3 keys

Reads S3 credentials directly from the model auth secret mount (`/var/run/secrets/model/`). Supports standard AWS key names in uppercase (`AWS_ACCESS_KEY_ID`), lowercase (`aws_access_key_id`), and custom `s3_*` prefixed names (`s3_access_key`) — first non-empty match wins per field.

## Cluster setup for sidecar proxy path (step 3)

**1. Add `k8s_url` and `k8s_sa_token` to the model auth secret:**

```bash
oc patch secret <model-secret> -n <namespace> --type merge -p '{
  "stringData": {
    "k8s_url": "<k8s-api-url>",
    "k8s_sa_token": ""
  }
}'
```

Get the K8s API URL with: `oc whoami --show-server`

Empty `k8s_sa_token` is intentional — the sidecar injects the pod SA token when the value is empty.

**2. Update `ca_cert` to include both the service CA and the cluster CA:**

The sidecar's model HTTP client uses `ca_cert` from the model auth secret as its sole trust anchor. By default this only contains the OpenShift service CA, but the K8s API server uses the cluster CA — so the sidecar fails with `x509: certificate signed by unknown authority`.

Combine both CAs into `ca_cert`:

```bash
oc get configmap openshift-service-ca.crt \
  -n openshift-config-managed \
  -o jsonpath='{.data.service-ca\.crt}' > /tmp/combined-ca.crt

oc get configmap kube-root-ca.crt \
  -n <namespace> \
  -o jsonpath='{.data.ca\.crt}' >> /tmp/combined-ca.crt

CA_B64=$(base64 -i /tmp/combined-ca.crt)
oc patch secret <model-secret> -n <namespace> --type merge \
  -p "{\"data\":{\"ca_cert\":\"$CA_B64\"}}"
```

## Test plan

- [x] All 324 existing tests pass (no regressions)
- [x] 13 new tests covering each cascade step, sidecar proxy, model auth key resolution (uppercase/lowercase/custom precedence), and env-var fallback
- [x] Verified on cluster: KFP quick-scan with sidecar proxy — S3 credentials read successfully via step 3, 6 files downloaded from S3

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Implement a cascading S3 credential resolution chain for the evalhub Garak adapter to ensure results can be downloaded in KFP and sidecar proxy environments.

New Features:
- Add sidecar proxy-based secret reader and model auth secret S3 credential reader as additional sources for S3 configuration.
- Add environment variable fallback for S3 access key, secret key, and region when secret-based values are missing.

Tests:
- Add comprehensive tests covering the five-step S3 credential resolution cascade, including sidecar proxy and model auth secret paths, and env-var precedence over other sources.