### PR TITLE
fix: unify API key resolution for intents roles across non-kfp and KFP modes

### DIFF
--- a/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
+++ b/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
@@ -128,9 +128,9 @@ def resolve_api_key(role: str) -> str:
     at ``/mnt/model-auth`` (KFP mode), or the evalhub model auth secret
     at ``/var/run/secrets/model/`` (simple mode).
 
-    Both uppercase (``JUDGE_API_KEY``) and lowercase hyphenated
-    (``judge-api-key``) key names are checked to support common K8s
-    Secret naming conventions.
+    Both uppercase (``JUDGE_API_KEY``), lowercase hyphenated
+    (``judge-api-key``), and EvalHub multi-model convention
+    (``judge_api-key``) key names are checked.
 
     Resolution order (first non-empty wins):
 
@@ -139,22 +139,27 @@ def resolve_api_key(role: str) -> str:
     3.  ``{ROLE}_API_KEY`` evalhub secret (``/var/run/secrets/model/``)
     4.  ``{role}-api-key`` KFP secret file (lowercase, K8s convention)
     5.  ``{role}-api-key`` evalhub secret
-    6.  ``API_KEY`` env var          (generic fallback)
-    7.  ``API_KEY`` KFP secret file
-    8.  ``API_KEY`` evalhub secret
-    9.  ``api-key`` KFP secret file  (EvalHub convention)
-    10. ``api-key`` evalhub secret   (EvalHub convention)
-    11. ``"DUMMY"``                  (unauthenticated / local endpoints)
+    6.  ``{role}_api-key`` KFP secret file (EvalHub multi-model convention)
+    7.  ``{role}_api-key`` evalhub secret
+    8.  ``API_KEY`` env var          (generic fallback)
+    9.  ``API_KEY`` KFP secret file
+    10. ``API_KEY`` evalhub secret
+    11. ``api-key`` KFP secret file  (EvalHub convention)
+    12. ``api-key`` evalhub secret   (EvalHub convention)
+    13. ``"DUMMY"``                  (unauthenticated / local endpoints)
     """
     role_upper = role.upper()
     role_var = f"{role_upper}_API_KEY"
     role_lower = f"{role.lower()}-api-key"
+    role_evalhub = f"{role.lower()}_api-key"
     return (
         os.environ.get(role_var)
         or _read_secret_file(role_var)
         or _read_evalhub_secret(role_var)
         or _read_secret_file(role_lower)
         or _read_evalhub_secret(role_lower)
+        or _read_secret_file(role_evalhub)
+        or _read_evalhub_secret(role_evalhub)
         or os.environ.get("API_KEY")
         or _read_secret_file("API_KEY")
         or _read_evalhub_secret("API_KEY")
@@ -203,13 +208,70 @@ def _resolve_config_api_keys(config: dict) -> None:
     _PLACEHOLDERS = {"", "DUMMY", "__FROM_ENV__", "***"}
 
     def _is_placeholder(value: str) -> bool:
-        return value.strip().upper() in _PLACEHOLDERS
+        stripped = value.strip()
+        if stripped.endswith(":ref"):
+            return False
+        return stripped.upper() in _PLACEHOLDERS
+
+    _ROLE_URL_KEYS = {
+        "JUDGE": ["judge_url"],
+        "ATTACKER": ["attacker_url", "judge_url"],
+        "EVALUATOR": ["evaluator_url", "judge_url"],
+        "TRANSLATION": ["translation_url", "attacker_url", "judge_url"],
+    }
+
+    def _is_sidecar_uri(value: str) -> bool:
+        return not value or "localhost" in value or "127.0.0.1" in value
+
+    def _resolve_uri(role: str, current_uri: str) -> str:
+        """Resolve URI from mounted secret when current value is a sidecar address."""
+        if not _is_sidecar_uri(current_uri):
+            return current_uri
+        secret_keys = _ROLE_URL_KEYS.get(role, [])
+        for secret_key in secret_keys:
+            real_url = _read_secret_file(secret_key) or _read_evalhub_secret(secret_key)
+            if real_url:
+                return real_url.strip().rstrip("/")
+        return current_uri
+
+    _ROLE_KEY_FALLBACKS = {
+        "ATTACKER": ["JUDGE"],
+        "EVALUATOR": ["JUDGE"],
+        "TRANSLATION": ["ATTACKER", "JUDGE"],
+    }
+
+    def _has_role_specific_key(role: str) -> str:
+        """Check only role-specific keys (not generic fallbacks)."""
+        role_lower = role.lower()
+        return (
+            os.environ.get(f"{role}_API_KEY")
+            or _read_secret_file(f"{role}_API_KEY")
+            or _read_secret_file(f"{role_lower}-api-key")
+            or _read_secret_file(f"{role_lower}_api-key")
+            or _read_evalhub_secret(f"{role}_API_KEY")
+            or _read_evalhub_secret(f"{role_lower}-api-key")
+            or _read_evalhub_secret(f"{role_lower}_api-key")
+            or ""
+        )
+
+    def _resolve_key_with_fallback(role: str) -> str:
+        """Resolve API key for role, falling back to related roles before generic."""
+        own_key = _has_role_specific_key(role)
+        if own_key:
+            return own_key
+        for fallback_role in _ROLE_KEY_FALLBACKS.get(role, []):
+            fallback_key = _has_role_specific_key(fallback_role)
+            if fallback_key:
+                return fallback_key
+        return resolve_api_key(role)
 
     def _walk(obj: Any, role: str = "TARGET") -> None:
         if isinstance(obj, dict):
             if "api_key" in obj and isinstance(obj["api_key"], str):
                 if _is_placeholder(obj["api_key"]):
-                    obj["api_key"] = resolve_api_key(role)
+                    obj["api_key"] = _resolve_key_with_fallback(role)
+            if "uri" in obj and isinstance(obj["uri"], str):
+                obj["uri"] = _resolve_uri(role, obj["uri"])
             for key, val in obj.items():
                 child_role = role
                 if key == "detector_model_config":
@@ -248,7 +310,7 @@ _HF_LANGPROVIDERS = [
 ]
 
 
-def _build_llm_langproviders(url: str, name: str) -> list[dict[str, str]]:
+def _build_llm_langproviders(url: str, name: str, api_key: str = "__FROM_ENV__") -> list[dict[str, str]]:
     """Build ``llm.LLMTranslator`` langprovider entries for zh/en pair."""
     return [
         {
@@ -256,14 +318,14 @@ def _build_llm_langproviders(url: str, name: str) -> list[dict[str, str]]:
             "model_type": "llm.LLMTranslator",
             "uri": url,
             "model_name": name,
-            "api_key": "__FROM_ENV__",
+            "api_key": api_key,
         },
         {
             "language": "en,zh",
             "model_type": "llm.LLMTranslator",
             "uri": url,
             "model_name": name,
-            "api_key": "__FROM_ENV__",
+            "api_key": api_key,
         },
     ]
 
@@ -280,7 +342,9 @@ def build_translation_langproviders(
     benchmark_config: dict[str, Any],
     attacker_url: str = "",
     attacker_name: str = "",
+    attacker_api_key: str = "",
     probe_spec: str = "",
+    model_url: str = "",
 ) -> list[dict[str, str]] | None:
     """Resolve langproviders for the ``multilingual.TranslationIntent`` probe.
 
@@ -292,15 +356,17 @@ def build_translation_langproviders(
 
     1. ``translation_use_hf=True`` in *benchmark_config* -- use HuggingFace
        ``local.LocalHFTranslator`` models (Helsinki-NLP).
-    2. ``intents_models.translation`` has ``url`` + ``name`` -- use a
+    2. ``translation_url`` / ``translation_api-key`` from the evalhub model
+       auth secret (sidecar multi-model convention).
+    3. ``intents_models.translation`` has ``url`` + ``name`` -- use a
        dedicated LLM endpoint via ``llm.LLMTranslator``.
-    3. *attacker_url* / *attacker_name* available (from the resolved
+    4. *attacker_url* / *attacker_name* available (from the resolved
        attacker model) -- reuse the attacker LLM for translation.
-    4. Fallback to HF models (safety net when no LLM is available).
+    5. Fallback to HF models (safety net when no LLM is available).
 
     API keys for LLM translators use the ``__FROM_ENV__`` placeholder
     and are resolved at pod level by :func:`_resolve_config_api_keys`
-    with role ``TRANSLATION``.
+    with role ``TRANSLATION``, unless a ref token is read from the secret.
     """
     if probe_spec and not _probe_spec_includes_translation(probe_spec):
         logger.info("TranslationIntent not in probe_spec — skipping langproviders")
@@ -312,6 +378,24 @@ def build_translation_langproviders(
         logger.info("Translation mode: HF (translation_use_hf=True)")
         return list(_HF_LANGPROVIDERS)
 
+    try:
+        from evalhub.adapter.auth import read_model_auth_key
+
+        trans_secret_url = read_model_auth_key("translation_url")
+        trans_secret_key = read_model_auth_key("translation_api-key")
+        if trans_secret_url or trans_secret_key:
+            effective_url = trans_secret_url or model_url
+            effective_key = trans_secret_key or read_model_auth_key("api-key") or "__FROM_ENV__"
+            intents_models = benchmark_config.get("intents_models", {})
+            if not isinstance(intents_models, dict):
+                intents_models = {}
+            translation_cfg = intents_models.get("translation") or {}
+            trans_name = translation_cfg.get("name") or "translation-model"
+            logger.info("Translation mode: secret-based LLM (%s)", trans_name)
+            return _build_llm_langproviders(effective_url, trans_name, api_key=effective_key)
+    except ImportError:
+        pass
+
     intents_models = benchmark_config.get("intents_models", {})
     if not isinstance(intents_models, dict):
         intents_models = {}
@@ -322,8 +406,9 @@ def build_translation_langproviders(
         return _build_llm_langproviders(translation_cfg["url"], translation_cfg["name"])
 
     if attacker_url and attacker_name:
+        api_key = attacker_api_key or "__FROM_ENV__"
         logger.info("Translation mode: attacker LLM (%s)", attacker_name)
-        return _build_llm_langproviders(attacker_url, attacker_name)
+        return _build_llm_langproviders(attacker_url, attacker_name, api_key=api_key)
 
     logger.info("Translation mode: HF fallback (no LLM available)")
     return list(_HF_LANGPROVIDERS)
@@ -410,21 +495,33 @@ def run_sdg_generation(
     sdg_max_concurrency: int = 0,
     sdg_num_samples: int = 0,
     sdg_max_tokens: int = 0,
+    api_key: str | None = None,
 ) -> pd.DataFrame:
     """Run Synthetic Data Generation on a taxonomy.  Returns the raw DataFrame.
 
-    The SDG API key is resolved via ``resolve_api_key("sdg")`` which reads
-    ``SDG_API_KEY`` or ``API_KEY`` environment variables (injected from a
-    Kubernetes Secret in KFP mode), falling back to ``"DUMMY"``.
+    When *api_key* is provided (e.g. a sidecar ref token), it is used
+    directly.  Otherwise the key is resolved via ``resolve_api_key("sdg")``
+    which reads ``SDG_API_KEY`` or ``API_KEY`` environment variables
+    (injected from a Kubernetes Secret in KFP mode), falling back to
+    ``"DUMMY"``.
     """
     from ..sdg import generate_sdg_dataset
 
     if not sdg_model or not sdg_model.strip():
         raise GarakValidationError("sdg_model is required for intents scans when SDG must run.")
-    if not sdg_api_base or not sdg_api_base.strip():
-        raise GarakValidationError("sdg_api_base is required for intents scans when SDG must run.")
 
-    effective_key = resolve_api_key("sdg")
+    # Resolve SDG URL from mounted secret if sidecar address or empty
+    effective_base = sdg_api_base
+    if not effective_base or "localhost" in effective_base or "127.0.0.1" in effective_base:
+        secret_url = _read_secret_file("sdg_url") or _read_evalhub_secret("sdg_url")
+        if secret_url:
+            effective_base = secret_url.strip().rstrip("/")
+            logger.info("Resolved sdg_api_base from secret: %s", effective_base)
+    if not effective_base or not effective_base.strip():
+        raise GarakValidationError("sdg_api_base is required for intents scans when SDG must run.")
+    sdg_api_base = effective_base
+
+    effective_key = api_key or resolve_api_key("sdg")
 
     effective_flow_id = (sdg_flow_id.strip() if sdg_flow_id else "") or DEFAULT_SDG_FLOW_ID
 

--- a/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
+++ b/src/llama_stack_provider_trustyai_garak/core/pipeline_steps.py
@@ -77,8 +77,10 @@ logger = logging.getLogger(__name__)
 # How it works
 # ------------
 # - **Simple mode**: The EvalHub service mounts the secret at
-#   ``/var/run/secrets/model/``. The adapter reads ``api-key`` via the
-#   EvalHub SDK's ``read_model_auth_key()``.
+#   ``/var/run/secrets/model/``. ``resolve_api_key(role)`` checks both
+#   the KFP path and the evalhub SDK path via ``read_model_auth_key()``,
+#   so role-specific keys (e.g. ``JUDGE_API_KEY``) are resolved from
+#   whichever mount point exists.
 # - **KFP mode**: The pipeline mounts the secret at ``/mnt/model-auth``
 #   via ``use_secret_as_volume(optional=True)``. ``resolve_api_key(role)``
 #   reads files from that path.
@@ -102,29 +104,62 @@ def _read_secret_file(name: str) -> str:
         return ""
 
 
+def _read_evalhub_secret(name: str) -> str:
+    """Read a key from the evalhub model auth secret (simple mode).
+
+    In simple (non-KFP) mode, the eval-hub service mounts the model auth
+    secret at ``/var/run/secrets/model/``.  This function delegates to the
+    evalhub SDK's ``read_model_auth_key`` which reads from that path.
+
+    Returns the value or empty string if unavailable.
+    """
+    try:
+        from evalhub.adapter.auth import read_model_auth_key
+
+        return read_model_auth_key(name) or ""
+    except ImportError:
+        return ""
+
+
 def resolve_api_key(role: str) -> str:
     """Resolve an API key for a model role.
 
-    Keys may come from environment variables (e.g. local / simple mode)
-    or from a Kubernetes Secret mounted as a volume at
-    ``/mnt/model-auth`` (KFP mode).
+    Keys may come from environment variables, a Kubernetes Secret mounted
+    at ``/mnt/model-auth`` (KFP mode), or the evalhub model auth secret
+    at ``/var/run/secrets/model/`` (simple mode).
+
+    Both uppercase (``JUDGE_API_KEY``) and lowercase hyphenated
+    (``judge-api-key``) key names are checked to support common K8s
+    Secret naming conventions.
 
     Resolution order (first non-empty wins):
 
-    1. ``{ROLE}_API_KEY`` env var  (e.g. ``SDG_API_KEY``)
-    2. ``{ROLE}_API_KEY`` secret file
-    3. ``API_KEY`` env var          (generic fallback)
-    4. ``API_KEY`` secret file
-    5. ``api-key`` secret file      (EvalHub SDK convention)
-    6. ``"DUMMY"``                  (unauthenticated / local endpoints)
+    1.  ``{ROLE}_API_KEY`` env var  (e.g. ``SDG_API_KEY``)
+    2.  ``{ROLE}_API_KEY`` KFP secret file (``/mnt/model-auth/``)
+    3.  ``{ROLE}_API_KEY`` evalhub secret (``/var/run/secrets/model/``)
+    4.  ``{role}-api-key`` KFP secret file (lowercase, K8s convention)
+    5.  ``{role}-api-key`` evalhub secret
+    6.  ``API_KEY`` env var          (generic fallback)
+    7.  ``API_KEY`` KFP secret file
+    8.  ``API_KEY`` evalhub secret
+    9.  ``api-key`` KFP secret file  (EvalHub convention)
+    10. ``api-key`` evalhub secret   (EvalHub convention)
+    11. ``"DUMMY"``                  (unauthenticated / local endpoints)
     """
-    role_var = f"{role.upper()}_API_KEY"
+    role_upper = role.upper()
+    role_var = f"{role_upper}_API_KEY"
+    role_lower = f"{role.lower()}-api-key"
     return (
         os.environ.get(role_var)
         or _read_secret_file(role_var)
+        or _read_evalhub_secret(role_var)
+        or _read_secret_file(role_lower)
+        or _read_evalhub_secret(role_lower)
         or os.environ.get("API_KEY")
         or _read_secret_file("API_KEY")
+        or _read_evalhub_secret("API_KEY")
         or _read_secret_file("api-key")
+        or _read_evalhub_secret("api-key")
         or "DUMMY"
     )
 

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -505,16 +505,7 @@ class GarakAdapter(FrameworkAdapter):
             sdg_api_base = intents_params.get("sdg_api_base", "")
 
             sdg_secret_url, sdg_secret_key = self._read_role_from_secret("sdg", config.model.url)
-            if sdg_secret_url:
-                params = config.parameters or {}
-                sdg_role_cfg = (params.get("intents_models") or {}).get("sdg") or {}
-                sdg_append_v1 = as_bool(sdg_role_cfg.get("append_v1", True))
-                if sdg_append_v1:
-                    effective_sdg_base = self._normalize_url(sdg_secret_url)
-                else:
-                    effective_sdg_base = sdg_secret_url
-            else:
-                effective_sdg_base = sdg_api_base
+            effective_sdg_base = sdg_secret_url or sdg_api_base
             sdg_source = "model auth secret" if sdg_secret_url else "intents_params (job request)"
             logger.info("Intents sdg model: api_base=%s (source: %s)", effective_sdg_base, sdg_source)
             if not sdg_model or not effective_sdg_base:
@@ -1214,7 +1205,7 @@ class GarakAdapter(FrameworkAdapter):
             )
             raw_model_url = self._resolve_kfp_model_url(config.model.url, benchmark_config)
             garak_config.plugins.generators = build_generator_options(
-                model_endpoint=self._normalize_url(raw_model_url),
+                model_endpoint=raw_model_url.strip().rstrip("/"),
                 model_name=config.model.name,
                 api_key=api_key,
                 extra_params=model_params or TARGET_DEFAULT_PARAMETERS,
@@ -1424,25 +1415,13 @@ class GarakAdapter(FrameworkAdapter):
             if not evaluator_secret_url and not evaluator_secret_key:
                 evaluator_secret_url, evaluator_secret_key = judge_secret_url, judge_secret_key
 
-        # Sidecar returns host only (no path). Append /v1 by default for
-        # models that serve behind a versioned API path. Per-role
-        # "append_v1" flag (defaults to true) in intents_models config
-        # controls this: set to false for endpoints that don't use /v1.
-        def _should_append_v1(role_cfg: dict) -> bool:
-            return as_bool(role_cfg.get("append_v1", True))
-
-        def _resolve_url(secret_url: str | None, fallback_url: str, role_cfg: dict) -> str:
-            if secret_url:
-                return self._normalize_url(secret_url) if _should_append_v1(role_cfg) else secret_url
-            return fallback_url
-
-        effective_judge_url = _resolve_url(judge_secret_url, judge_url, judge_cfg)
+        effective_judge_url = judge_secret_url or judge_url
         effective_judge_key = judge_secret_key or _PLACEHOLDER
 
-        effective_attacker_url = _resolve_url(attacker_secret_url, attacker_url, attacker_cfg)
+        effective_attacker_url = attacker_secret_url or attacker_url
         effective_attacker_key = attacker_secret_key or _PLACEHOLDER
 
-        effective_evaluator_url = _resolve_url(evaluator_secret_url, evaluator_url, evaluator_cfg)
+        effective_evaluator_url = evaluator_secret_url or evaluator_url
         effective_evaluator_key = evaluator_secret_key or _PLACEHOLDER
 
         for role, eff_url, name, from_secret in [
@@ -1607,12 +1586,6 @@ class GarakAdapter(FrameworkAdapter):
             return key
 
         return "DUMMY"
-
-    def _normalize_url(self, url: str) -> str:
-        """Normalize model URL to include /v1 suffix if needed."""
-        from ..utils import normalize_model_url
-
-        return normalize_model_url(url)
 
     @staticmethod
     def _is_sidecar_address(url: str) -> bool:

--- a/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
+++ b/src/llama_stack_provider_trustyai_garak/evalhub/garak_adapter.py
@@ -503,7 +503,21 @@ class GarakAdapter(FrameworkAdapter):
             logger.info("Running Synthetic Data Generation")
             sdg_model = intents_params.get("sdg_model", "")
             sdg_api_base = intents_params.get("sdg_api_base", "")
-            if not sdg_model or not sdg_api_base:
+
+            sdg_secret_url, sdg_secret_key = self._read_role_from_secret("sdg", config.model.url)
+            if sdg_secret_url:
+                params = config.parameters or {}
+                sdg_role_cfg = (params.get("intents_models") or {}).get("sdg") or {}
+                sdg_append_v1 = as_bool(sdg_role_cfg.get("append_v1", True))
+                if sdg_append_v1:
+                    effective_sdg_base = self._normalize_url(sdg_secret_url)
+                else:
+                    effective_sdg_base = sdg_secret_url
+            else:
+                effective_sdg_base = sdg_api_base
+            sdg_source = "model auth secret" if sdg_secret_url else "intents_params (job request)"
+            logger.info("Intents sdg model: api_base=%s (source: %s)", effective_sdg_base, sdg_source)
+            if not sdg_model or not effective_sdg_base:
                 raise ValueError(
                     "Intents benchmark requires sdg_model and sdg_api_base "
                     "for prompt generation when intents_s3_key is not provided."
@@ -512,11 +526,12 @@ class GarakAdapter(FrameworkAdapter):
             raw_df = run_sdg_generation(
                 taxonomy_df=taxonomy_df,
                 sdg_model=sdg_model,
-                sdg_api_base=sdg_api_base,
+                sdg_api_base=effective_sdg_base,
                 sdg_flow_id=intents_params.get("sdg_flow_id", DEFAULT_SDG_FLOW_ID),
                 sdg_max_concurrency=intents_params.get("sdg_max_concurrency", DEFAULT_SDG_MAX_CONCURRENCY),
                 sdg_num_samples=intents_params.get("sdg_num_samples", DEFAULT_SDG_NUM_SAMPLES),
                 sdg_max_tokens=intents_params.get("sdg_max_tokens", DEFAULT_SDG_MAX_TOKENS),
+                api_key=sdg_secret_key,
             )
             raw_content = raw_df.to_csv(index=False)
             logger.info("SDG produced %d rows", len(raw_df))
@@ -622,12 +637,8 @@ class GarakAdapter(FrameworkAdapter):
                         "sdg_model for prompt generation when intents_s3_key "
                         "is not provided."
                     )
-                if not ip.get("sdg_api_base"):
-                    raise ValueError(
-                        "Intents benchmark (art_intents=True) requires "
-                        "sdg_api_base for prompt generation when intents_s3_key "
-                        "is not provided."
-                    )
+                # sdg_api_base may be empty here — the KFP SDG pod will
+                # resolve it from the mounted secret (sdg_url) at runtime.
 
         logger.info("Submitting KFP pipeline for %s", config.benchmark_id)
         callbacks.report_status(JobStatusUpdate(status=JobStatus.RUNNING, phase=JobPhase.RUNNING_EVALUATION))
@@ -1243,7 +1254,9 @@ class GarakAdapter(FrameworkAdapter):
         }
 
         if art_intents:
-            sdg_params, attacker_info = self._apply_intents_model_config(garak_config, benchmark_config, profile)
+            sdg_params, attacker_info = self._apply_intents_model_config(
+                garak_config, benchmark_config, profile, model_url=config.model.url
+            )
             intents_params.update(sdg_params)
 
             from ..core.pipeline_steps import build_translation_langproviders
@@ -1256,7 +1269,9 @@ class GarakAdapter(FrameworkAdapter):
                 benchmark_config,
                 attacker_url=attacker_info.get("url", ""),
                 attacker_name=attacker_info.get("name", ""),
+                attacker_api_key=attacker_info.get("api_key", ""),
                 probe_spec=resolved_probe_spec,
+                model_url=config.model.url,
             )
             if langproviders is not None:
                 garak_config.run.langproviders = langproviders
@@ -1272,6 +1287,7 @@ class GarakAdapter(FrameworkAdapter):
         garak_config: GarakCommandConfig,
         benchmark_config: dict,
         profile: dict,
+        model_url: str = "",
     ) -> tuple[dict[str, Any], dict[str, str]]:
         """Configure judge/attacker/evaluator/SDG models from ``intents_models``.
 
@@ -1329,26 +1345,36 @@ class GarakAdapter(FrameworkAdapter):
             if cfg.get("url")
         }
 
+        # Check if model auth secret has role URLs (secret-only config)
+        secret_has_roles = False
         if len(provided) == 0:
+            judge_probe_url, _ = self._read_role_from_secret("judge", model_url)
+            if judge_probe_url:
+                secret_has_roles = True
+
+        if len(provided) == 0 and not secret_has_roles:
             if garak_config.plugins and self._models_preconfigured_in_garak_config(garak_config.plugins):
                 logger.info(
                     "No intents_models provided but models are already "
                     "configured in garak_config — skipping intents_models "
-                    "override. API keys will be resolved by "
-                    "_resolve_config_api_keys in the KFP pod."
+                    "override."
                 )
                 preconfigured_attacker = self._extract_preconfigured_attacker(garak_config.plugins)
                 return self._extract_sdg_params(sdg_cfg, benchmark_config, profile), preconfigured_attacker
 
-            raise ValueError(
-                "Intents benchmark requires model configuration for "
-                "judge/attacker/evaluator roles. Either:\n"
-                "  1. Provide intents_models with at least one role "
-                "(url + name), or\n"
-                "  2. Configure models directly in garak_config "
-                "(plugins.detectors.judge with detector_model_name and "
-                "detector_model_config.uri)."
-            )
+            # Check if names are provided (secret has URLs, user only provides names)
+            has_names = any(cfg.get("name") for cfg in [judge_cfg, attacker_cfg, evaluator_cfg])
+            if not has_names:
+                raise ValueError(
+                    "Intents benchmark requires model configuration for "
+                    "judge/attacker/evaluator roles. Either:\n"
+                    "  1. Provide intents_models with at least one role "
+                    "(url + name, or just name if URLs are in the model auth secret), or\n"
+                    "  2. Configure models directly in garak_config "
+                    "(plugins.detectors.judge with detector_model_name and "
+                    "detector_model_config.uri)."
+                )
+
         if len(provided) == 2:
             missing = {"judge", "attacker", "evaluator"} - set(provided)
             raise ValueError(
@@ -1363,21 +1389,69 @@ class GarakAdapter(FrameworkAdapter):
             attacker_cfg = {**base_cfg, **attacker_cfg}
             evaluator_cfg = {**base_cfg, **evaluator_cfg}
 
+        # Fan-out names: if only judge has a name (secret-based config
+        # where URLs come from secret, user only specifies judge name),
+        # propagate it to attacker/evaluator.
+        if judge_cfg.get("name") and not attacker_cfg.get("name"):
+            attacker_cfg["name"] = judge_cfg["name"]
+        if judge_cfg.get("name") and not evaluator_cfg.get("name"):
+            evaluator_cfg["name"] = judge_cfg["name"]
+
         for role, cfg in [("judge", judge_cfg), ("attacker", attacker_cfg), ("evaluator", evaluator_cfg)]:
             if not cfg.get("name"):
                 raise ValueError(f"intents_models.{role}.name is required. Provide a model identifier for the {role}.")
 
-        judge_url = judge_cfg["url"]
+        judge_url = judge_cfg.get("url", "")
         judge_name = judge_cfg["name"]
 
-        attacker_url = attacker_cfg["url"]
+        attacker_url = attacker_cfg.get("url", "")
         attacker_name = attacker_cfg["name"]
 
-        evaluator_url = evaluator_cfg["url"]
+        evaluator_url = evaluator_cfg.get("url", "")
         evaluator_name = evaluator_cfg["name"]
 
-        # Use placeholder — real keys are injected via K8s Secret at pod level
         _PLACEHOLDER = "__FROM_ENV__"
+
+        judge_secret_url, judge_secret_key = self._read_role_from_secret("judge", model_url)
+        attacker_secret_url, attacker_secret_key = self._read_role_from_secret("attacker", model_url)
+        evaluator_secret_url, evaluator_secret_key = self._read_role_from_secret("evaluator", model_url)
+
+        # Fan-out: if judge has secret credentials but attacker/evaluator
+        # don't, inherit from judge (same model for all roles).
+        if judge_secret_url:
+            if not attacker_secret_url and not attacker_secret_key:
+                attacker_secret_url, attacker_secret_key = judge_secret_url, judge_secret_key
+            if not evaluator_secret_url and not evaluator_secret_key:
+                evaluator_secret_url, evaluator_secret_key = judge_secret_url, judge_secret_key
+
+        # Sidecar returns host only (no path). Append /v1 by default for
+        # models that serve behind a versioned API path. Per-role
+        # "append_v1" flag (defaults to true) in intents_models config
+        # controls this: set to false for endpoints that don't use /v1.
+        def _should_append_v1(role_cfg: dict) -> bool:
+            return as_bool(role_cfg.get("append_v1", True))
+
+        def _resolve_url(secret_url: str | None, fallback_url: str, role_cfg: dict) -> str:
+            if secret_url:
+                return self._normalize_url(secret_url) if _should_append_v1(role_cfg) else secret_url
+            return fallback_url
+
+        effective_judge_url = _resolve_url(judge_secret_url, judge_url, judge_cfg)
+        effective_judge_key = judge_secret_key or _PLACEHOLDER
+
+        effective_attacker_url = _resolve_url(attacker_secret_url, attacker_url, attacker_cfg)
+        effective_attacker_key = attacker_secret_key or _PLACEHOLDER
+
+        effective_evaluator_url = _resolve_url(evaluator_secret_url, evaluator_url, evaluator_cfg)
+        effective_evaluator_key = evaluator_secret_key or _PLACEHOLDER
+
+        for role, eff_url, name, from_secret in [
+            ("judge", effective_judge_url, judge_name, judge_secret_url),
+            ("attacker", effective_attacker_url, attacker_name, attacker_secret_url),
+            ("evaluator", effective_evaluator_url, evaluator_name, evaluator_secret_url),
+        ]:
+            source = "model auth secret" if from_secret else "intents_models (job request)"
+            logger.info("Intents %s model: name=%s, url=%s (source: %s)", role, name, eff_url, source)
 
         plugins = garak_config.plugins
 
@@ -1386,8 +1460,8 @@ class GarakAdapter(FrameworkAdapter):
         existing_judge["detector_model_type"] = existing_judge.get("detector_model_type") or "openai.OpenAICompatible"
         existing_judge["detector_model_name"] = existing_judge.get("detector_model_name") or judge_name
         existing_det_cfg = existing_judge.get("detector_model_config", {})
-        existing_det_cfg["uri"] = existing_det_cfg.get("uri") or judge_url
-        existing_det_cfg["api_key"] = _PLACEHOLDER
+        existing_det_cfg["uri"] = existing_det_cfg.get("uri") or effective_judge_url
+        existing_det_cfg["api_key"] = effective_judge_key
         existing_judge["detector_model_config"] = existing_det_cfg
         plugins.detectors["judge"] = existing_judge
 
@@ -1397,21 +1471,21 @@ class GarakAdapter(FrameworkAdapter):
                 tap_cfg["attack_model_name"] = tap_cfg.get("attack_model_name") or attacker_name
                 existing_attack_cfg = tap_cfg.get("attack_model_config", {})
                 existing_attack_cfg.setdefault("max_tokens", 500)
-                existing_attack_cfg["uri"] = existing_attack_cfg.get("uri") or attacker_url
-                existing_attack_cfg["api_key"] = _PLACEHOLDER
+                existing_attack_cfg["uri"] = existing_attack_cfg.get("uri") or effective_attacker_url
+                existing_attack_cfg["api_key"] = effective_attacker_key
                 tap_cfg["attack_model_config"] = existing_attack_cfg
 
                 tap_cfg["evaluator_model_name"] = tap_cfg.get("evaluator_model_name") or evaluator_name
                 existing_eval_cfg = tap_cfg.get("evaluator_model_config", {})
                 existing_eval_cfg.setdefault("max_tokens", 10)
                 existing_eval_cfg.setdefault("temperature", 0.0)
-                existing_eval_cfg["uri"] = existing_eval_cfg.get("uri") or evaluator_url
-                existing_eval_cfg["api_key"] = _PLACEHOLDER
+                existing_eval_cfg["uri"] = existing_eval_cfg.get("uri") or effective_evaluator_url
+                existing_eval_cfg["api_key"] = effective_evaluator_key
                 tap_cfg["evaluator_model_config"] = existing_eval_cfg
 
                 plugins.probes["tap"]["TAPIntent"] = tap_cfg
 
-        attacker_info = {"url": attacker_url, "name": attacker_name}
+        attacker_info = {"url": effective_attacker_url, "name": attacker_name, "api_key": effective_attacker_key}
         return self._extract_sdg_params(sdg_cfg, benchmark_config, profile), attacker_info
 
     @staticmethod
@@ -1458,20 +1532,24 @@ class GarakAdapter(FrameworkAdapter):
         benchmark_config: dict,
         profile: dict,
     ) -> dict[str, str]:
-        """Extract SDG model params from intents_models.sdg or flat keys."""
+        """Extract SDG model params from intents_models.sdg or flat keys.
+
+        The SDG URL may come from the model auth secret (sdg_url) rather
+        than the job request, so ``name`` alone is sufficient — the URL
+        will be resolved later from the secret in ``_run_simple_intents``.
+        """
         sdg_params: dict[str, str] = {
             "sdg_model": "",
             "sdg_api_base": "",
         }
-        if sdg_cfg.get("url") and sdg_cfg.get("name"):
+        if sdg_cfg.get("name"):
             sdg_params["sdg_model"] = sdg_cfg["name"]
-            sdg_params["sdg_api_base"] = sdg_cfg["url"]
+            sdg_params["sdg_api_base"] = sdg_cfg.get("url", "")
         else:
             sdg_model = benchmark_config.get("sdg_model", profile.get("sdg_model", ""))
             sdg_api_base = benchmark_config.get("sdg_api_base", profile.get("sdg_api_base", ""))
-            if sdg_model and sdg_api_base:
-                sdg_params["sdg_model"] = sdg_model
-                sdg_params["sdg_api_base"] = sdg_api_base
+            sdg_params["sdg_model"] = sdg_model
+            sdg_params["sdg_api_base"] = sdg_api_base
         return sdg_params
 
     @staticmethod
@@ -1532,16 +1610,49 @@ class GarakAdapter(FrameworkAdapter):
 
     def _normalize_url(self, url: str) -> str:
         """Normalize model URL to include /v1 suffix if needed."""
-        import re
+        from ..utils import normalize_model_url
 
-        url = url.strip().rstrip("/")
-        if not re.match(r"^.*\/v\d+$", url):
-            url = f"{url}/v1"
-        return url
+        return normalize_model_url(url)
 
     @staticmethod
     def _is_sidecar_address(url: str) -> bool:
         return "localhost" in url or "127.0.0.1" in url
+
+    @staticmethod
+    def _read_role_from_secret(role: str, model_url: str = "") -> tuple[str | None, str | None]:
+        """Read URL and api-key for a role from evalhub model auth secret.
+
+        Returns (url, api_key) tuple.
+
+        Resolution logic:
+        - If <role>_url is in secret: use it (sidecar address)
+        - If <role>_api-key is in secret but <role>_url is not: use model_url
+          (sidecar default route -- same endpoint as target model)
+        - If neither is in secret: returns (None, None) -- unauthenticated
+        - If url is resolved but <role>_api-key is absent: fall back to
+          generic 'api-key'
+
+        Key naming follows EvalHub multi-model convention:
+        <role>_url, <role>_api-key.
+        """
+        try:
+            from evalhub.adapter.auth import read_model_auth_key
+        except ImportError:
+            return None, None
+
+        url = read_model_auth_key(f"{role}_url")
+        api_key = read_model_auth_key(f"{role}_api-key")
+
+        if not url and not api_key:
+            return None, None
+
+        if not url:
+            url = model_url
+
+        if not api_key:
+            api_key = read_model_auth_key("api-key")
+
+        return url, api_key
 
     @staticmethod
     def _resolve_kfp_model_url(model_url: str, benchmark_config: dict) -> str:

--- a/src/llama_stack_provider_trustyai_garak/utils.py
+++ b/src/llama_stack_provider_trustyai_garak/utils.py
@@ -4,10 +4,21 @@ import httpx
 import os
 from pathlib import Path
 from .constants import XDG_CACHE_HOME, XDG_DATA_HOME, XDG_CONFIG_HOME
+import re
 
 logger = logging.getLogger(__name__)
 
 _FALSY_STRINGS = frozenset({"false", "0", "no", "off", ""})
+
+_VERSION_PATH_RE = re.compile(r"^.*\/v\d+$")
+
+
+def normalize_model_url(url: str) -> str:
+    """Ensure model URL includes /v1 suffix for OpenAI-compatible endpoints."""
+    url = url.strip().rstrip("/")
+    if not _VERSION_PATH_RE.match(url):
+        url = f"{url}/v1"
+    return url
 
 
 def safe_int(value: Any, fallback: int) -> int:

--- a/src/llama_stack_provider_trustyai_garak/utils.py
+++ b/src/llama_stack_provider_trustyai_garak/utils.py
@@ -4,21 +4,10 @@ import httpx
 import os
 from pathlib import Path
 from .constants import XDG_CACHE_HOME, XDG_DATA_HOME, XDG_CONFIG_HOME
-import re
 
 logger = logging.getLogger(__name__)
 
 _FALSY_STRINGS = frozenset({"false", "0", "no", "off", ""})
-
-_VERSION_PATH_RE = re.compile(r"^.*\/v\d+$")
-
-
-def normalize_model_url(url: str) -> str:
-    """Ensure model URL includes /v1 suffix for OpenAI-compatible endpoints."""
-    url = url.strip().rstrip("/")
-    if not _VERSION_PATH_RE.match(url):
-        url = f"{url}/v1"
-    return url
 
 
 def safe_int(value: Any, fallback: int) -> int:

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -1567,7 +1567,11 @@ class TestJobPhaseReporting:
             def report_status(self, update):
                 statuses.append(update)
 
-        job = SimpleNamespace(benchmark_id="trustyai_garak::intents", parameters={})
+        job = SimpleNamespace(
+            benchmark_id="trustyai_garak::intents",
+            parameters={},
+            model=SimpleNamespace(url="http://localhost:8080", name="test-model"),
+        )
         intents_params = {
             "sdg_model": "sdg-m",
             "sdg_api_base": "http://sdg:7000/v1",
@@ -2834,6 +2838,67 @@ class TestTranslationLangproviders:
         assert "langproviders" not in run_config
 
 
+class TestReadRoleFromSecret:
+    """Tests for _read_role_from_secret static method."""
+
+    def _setup(self, monkeypatch, fake_read):
+        module = _load_evalhub_garak_adapter(monkeypatch)
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = fake_read
+        return module
+
+    def test_both_url_and_key_from_secret(self, monkeypatch):
+        def _fake(name):
+            return {"judge_url": "http://localhost:8080", "judge_api-key": "judge_api-key:ref"}.get(name)
+
+        module = self._setup(monkeypatch, _fake)
+        url, key = module.GarakAdapter._read_role_from_secret("judge", "http://fallback:8080")
+        assert url == "http://localhost:8080"
+        assert key == "judge_api-key:ref"
+
+    def test_key_present_url_absent_uses_model_url(self, monkeypatch):
+        def _fake(name):
+            return {"judge_api-key": "judge_api-key:ref"}.get(name)
+
+        module = self._setup(monkeypatch, _fake)
+        url, key = module.GarakAdapter._read_role_from_secret("judge", "http://localhost:8080")
+        assert url == "http://localhost:8080"
+        assert key == "judge_api-key:ref"
+
+    def test_url_present_key_absent_uses_generic_api_key(self, monkeypatch):
+        def _fake(name):
+            return {"judge_url": "http://localhost:8080", "api-key": "api-key:ref"}.get(name)
+
+        module = self._setup(monkeypatch, _fake)
+        url, key = module.GarakAdapter._read_role_from_secret("judge", "http://fallback:8080")
+        assert url == "http://localhost:8080"
+        assert key == "api-key:ref"
+
+    def test_neither_url_nor_key_returns_none(self, monkeypatch):
+        module = self._setup(monkeypatch, lambda name: None)
+        url, key = module.GarakAdapter._read_role_from_secret("judge", "http://localhost:8080")
+        assert url is None
+        assert key is None
+
+    def test_url_present_no_generic_key_returns_none_for_key(self, monkeypatch):
+        def _fake(name):
+            return {"sdg_url": "http://localhost:8080"}.get(name)
+
+        module = self._setup(monkeypatch, _fake)
+        url, key = module.GarakAdapter._read_role_from_secret("sdg", "http://fallback:8080")
+        assert url == "http://localhost:8080"
+        assert key is None
+
+    def test_secret_url_wins_over_job_request_url(self, monkeypatch):
+        def _fake(name):
+            return {"judge_url": "http://localhost:8080", "judge_api-key": "judge_api-key:ref"}.get(name)
+
+        module = self._setup(monkeypatch, _fake)
+        url, key = module.GarakAdapter._read_role_from_secret("judge", "http://real-model:9000/v1")
+        assert url == "http://localhost:8080"
+        assert key == "judge_api-key:ref"
+
+
 class TestResolveIntentsApiKey:
     """Tests for _resolve_intents_api_key static method."""
 
@@ -3299,6 +3364,58 @@ class TestSimpleIntentsMode:
         assert "category" in norm_df.columns
         assert "prompt" in norm_df.columns
         assert len(norm_df) == 2
+
+    def test_simple_intents_sdg_uses_secret_url_and_key(self, monkeypatch, tmp_path):
+        """SDG reads sdg_url and sdg_api-key from secret when available."""
+        module, adapter, job = self._make_adapter_and_job(monkeypatch, tmp_path)
+
+        auth_module = sys.modules["evalhub.adapter.auth"]
+        auth_module.read_model_auth_key = lambda name: {
+            "sdg_url": "http://localhost:8080",
+            "sdg_api-key": "sdg_api-key:ref",
+        }.get(name)
+
+        scan_dir = tmp_path / "simple-intents-job"
+        scan_dir.mkdir(parents=True, exist_ok=True)
+
+        import pandas as pd
+
+        fake_raw_df = pd.DataFrame({"policy_concept": ["X"], "concept_definition": ["x"], "prompt": ["p"]})
+
+        sdg_captured = {}
+
+        def _fake_run_sdg_generation(taxonomy_df, sdg_model, sdg_api_base, **kwargs):
+            sdg_captured["sdg_api_base"] = sdg_api_base
+            sdg_captured["api_key"] = kwargs.get("api_key")
+            return fake_raw_df
+
+        def _fake_setup_and_run(config_json, prompts_csv_path, scan_dir, timeout_seconds):
+            report_prefix = scan_dir / "scan"
+            report_prefix.with_suffix(".report.jsonl").write_text("{}", encoding="utf-8")
+            return module.GarakScanResult(returncode=0, stdout="", stderr="", report_prefix=report_prefix)
+
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.run_sdg_generation",
+            _fake_run_sdg_generation,
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.setup_and_run_garak",
+            _fake_setup_and_run,
+        )
+        monkeypatch.setattr(
+            module.GarakAdapter,
+            "_parse_results",
+            lambda self, result, eval_threshold, art_intents=False: ([], None, 0, {"total_attempts": 0}),
+        )
+
+        class _Callbacks:
+            def report_status(self, _update):
+                return None
+
+        adapter.run_benchmark_job(job, _Callbacks())
+
+        assert sdg_captured["sdg_api_base"] == "http://localhost:8080/v1"
+        assert sdg_captured["api_key"] == "sdg_api-key:ref"
 
 
 class TestKFPIntentsMode:

--- a/tests/test_evalhub_adapter.py
+++ b/tests/test_evalhub_adapter.py
@@ -3371,7 +3371,7 @@ class TestSimpleIntentsMode:
 
         auth_module = sys.modules["evalhub.adapter.auth"]
         auth_module.read_model_auth_key = lambda name: {
-            "sdg_url": "http://localhost:8080",
+            "sdg_url": "http://localhost:8080/v1",
             "sdg_api-key": "sdg_api-key:ref",
         }.get(name)
 

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -126,6 +126,67 @@ class TestResolveApiKey:
         )
         assert resolve_api_key("sdg") == "DUMMY"
 
+    def test_lowercase_hyphenated_key_from_volume(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        (tmp_path / "judge-api-key").write_text("lower-key")
+        assert resolve_api_key("judge") == "lower-key"
+
+    def test_uppercase_file_takes_precedence_over_lowercase(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        (tmp_path / "JUDGE_API_KEY").write_text("upper-key")
+        (tmp_path / "judge-api-key").write_text("lower-key")
+        assert resolve_api_key("judge") == "upper-key"
+
+    def test_evalhub_secret_role_specific_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: "evalhub-judge" if name == "JUDGE_API_KEY" else "",
+        )
+        assert resolve_api_key("judge") == "evalhub-judge"
+
+    def test_evalhub_secret_lowercase_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("SDG_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: "evalhub-sdg" if name == "sdg-api-key" else "",
+        )
+        assert resolve_api_key("sdg") == "evalhub-sdg"
+
+    def test_kfp_volume_takes_precedence_over_evalhub_secret(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        (tmp_path / "JUDGE_API_KEY").write_text("kfp-key")
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: "evalhub-key",
+        )
+        assert resolve_api_key("judge") == "kfp-key"
+
 
 class TestRedactApiKeys:
     def test_simple_redaction(self):

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -187,6 +187,47 @@ class TestResolveApiKey:
         )
         assert resolve_api_key("judge") == "kfp-key"
 
+    def test_evalhub_secret_generic_api_key_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: "evalhub-generic" if name == "API_KEY" else "",
+        )
+        assert resolve_api_key("judge") == "evalhub-generic"
+
+    def test_evalhub_secret_generic_lowercase_api_key_fallback(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: "evalhub-apikey" if name == "api-key" else "",
+        )
+        assert resolve_api_key("judge") == "evalhub-apikey"
+
+    def test_evalhub_secret_uppercase_takes_precedence_over_lowercase(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps._read_evalhub_secret",
+            lambda name: (
+                "evalhub-upper" if name == "JUDGE_API_KEY" else "evalhub-lower" if name == "judge-api-key" else ""
+            ),
+        )
+        assert resolve_api_key("judge") == "evalhub-upper"
+
 
 class TestRedactApiKeys:
     def test_simple_redaction(self):

--- a/tests/test_pipeline_steps.py
+++ b/tests/test_pipeline_steps.py
@@ -228,6 +228,27 @@ class TestResolveApiKey:
         )
         assert resolve_api_key("judge") == "evalhub-upper"
 
+    def test_evalhub_multimodel_naming_from_volume(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        (tmp_path / "judge_api-key").write_text("evalhub-multimodel")
+        assert resolve_api_key("judge") == "evalhub-multimodel"
+
+    def test_hyphenated_takes_precedence_over_evalhub_multimodel(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("JUDGE_API_KEY", raising=False)
+        monkeypatch.delenv("API_KEY", raising=False)
+        monkeypatch.setattr(
+            "llama_stack_provider_trustyai_garak.core.pipeline_steps.MODEL_AUTH_MOUNT_PATH",
+            str(tmp_path),
+        )
+        (tmp_path / "judge-api-key").write_text("hyphenated-key")
+        (tmp_path / "judge_api-key").write_text("evalhub-key")
+        assert resolve_api_key("judge") == "hyphenated-key"
+
 
 class TestRedactApiKeys:
     def test_simple_redaction(self):
@@ -469,6 +490,22 @@ class TestResolveConfigApiKeys:
         }
         _resolve_config_api_keys(config)
         assert "api_key" not in config["run"]["langproviders"][0]
+
+    def test_ref_tokens_not_treated_as_placeholders(self, monkeypatch):
+        from llama_stack_provider_trustyai_garak.core.pipeline_steps import _resolve_config_api_keys
+
+        monkeypatch.setenv("TARGET_API_KEY", "should-not-be-used")
+        monkeypatch.setenv("JUDGE_API_KEY", "should-not-be-used")
+
+        config = {
+            "plugins": {
+                "generators": {"openai": {"OpenAICompatible": {"api_key": "api-key:ref", "uri": "http://gen"}}},
+                "detectors": {"judge": {"detector_model_config": {"api_key": "judge_api-key:ref", "uri": "http://j"}}},
+            }
+        }
+        _resolve_config_api_keys(config)
+        assert config["plugins"]["generators"]["openai"]["OpenAICompatible"]["api_key"] == "api-key:ref"
+        assert config["plugins"]["detectors"]["judge"]["detector_model_config"]["api_key"] == "judge_api-key:ref"
 
 
 class TestBuildTranslationLangproviders:


### PR DESCRIPTION
## Summary

Implements sidecar-aware intents model authentication for both simple (non-KFP) and KFP execution modes, aligning with the EvalHub multi-model secret convention (`_api-key` / `_url` pairs).

### Core Changes

- **Secret-first resolution**: `_read_role_from_secret` reads role URLs and API keys from the evalhub model auth secret. Falls back to user-provided URLs from job params for unauthenticated models.
- **Fan-out logic**: When only judge credentials exist in the secret, attacker/evaluator/translation automatically inherit them (same model for all roles). Names also fan out from judge when not explicitly provided.
- **Sidecar ref token support**: `:ref` tokens from the sidecar are passed through as-is (not treated as placeholders by `_resolve_config_api_keys`).
- **KFP compatibility**: KFP pods resolve URIs and keys from the mounted real secret with fallback chain (`attacker` -> `judge` for missing roles). Same secret structure works for both modes.
- **EvalHub naming in `resolve_api_key`**: Checks `judge_api-key` (EvalHub multi-model convention) alongside `JUDGE_API_KEY` and `judge-api-key` for KFP compat.
- **No URL normalization**: URLs are used exactly as provided by the user or the secret. No `/v1` appending — relies on EvalHub preserving paths in `_url` values ([eval-hub#791](https://github.com/eval-hub/eval-hub/pull/791)).
- **SDG from secret**: `run_sdg_generation` accepts explicit `api_key` param; resolves `sdg_url` from mounted secret in KFP pods.
- **Translation routing**: Translation langproviders use attacker ref token for correct sidecar routing; KFP resolves from attacker/judge URL as fallback.

### Secret Structure (EvalHub multi-model convention)

```yaml
stringData:
  api-key: "sk-target-key"
  judge_api-key: "sk-judge-key"
  judge_url: "https://judge.example.com/v1"
  sdg_api-key: "sk-sdg-key"
  sdg_url: "https://sdg.example.com/v1"
  # attacker/evaluator optional — fan out from judge if absent
```

### Supported Scenarios

| Scenario | Secret keys needed | Job request |
|---|---|---|
| All roles same model, same key | `api-key` + all `*_url` | Names only |
| Per-role keys | `*_api-key` + `*_url` per role | Names only |
| Judge only (fan-out) | `judge_api-key` + `judge_url` + `sdg_*` | Judge + SDG names |
| Unauthenticated roles | No role keys in secret | Full URLs + names in intents_models |
| KFP mode | Same secret as above | Add `kfp_config` |

### Backwards Compatibility

- KFP mode with uppercase keys (`JUDGE_API_KEY`) still works
- Explicit URLs in `intents_models` still work (fallback when secret has no role keys)
- Pre-sidecar deployments (no secret) use `__FROM_ENV__` path as before

## Test plan

- [x] All 240 unit tests pass
- [x] Pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] Tested in cluster: non-KFP simple mode with all-roles secret
- [x] Tested in cluster: non-KFP with judge+sdg only (fan-out)
- [x] Tested in cluster: KFP mode with all-roles secret
- [x] Tested in cluster: KFP mode with judge+sdg only (fan-out)
- [x] Tested in cluster: KFP mode with unauthenticated models (URLs in job request)
- [x] Translation probe routing verified through sidecar and KFP